### PR TITLE
Map<String,Object> and hence JSON as source of bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github</groupId>
     <artifactId>strawberry</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>strawberry</name>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.2</version>
+        </dependency>
         
         <!-- Test dependencies -->
         <dependency>

--- a/src/main/java/com/github/strawberry/guice/Config.java
+++ b/src/main/java/com/github/strawberry/guice/Config.java
@@ -1,0 +1,74 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotate fields of your class into which an
+ * {@link com.google.inject.Injector} should inject values from a
+ * <a href="http://redis.io">Redis</a> database.
+ * 
+ * @author Wiehann Matthysen
+ */
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+@Documented
+public @interface Config {
+
+    /**
+     * The key-pattern to use when querying the Redis database for values to be
+     * injected into this field.
+     */
+    String value();
+
+    /**
+     * If false, a default value will be injected for the specified type if no
+     * matching value for the specified key-pattern exists in the Redis
+     * database. This default value is type dependent and only the following
+     * type are supported: {@code char([])} and {@code Character([])},
+     * {@code String}, {@code byte([])} and {@code Byte([]}, {@code boolean} and
+     * {@code Boolean}, {@code short} and {@code Short}, {@code int} and
+     * {@code Integer}, {@code long} and {@code Long}, {@code BigInteger},
+     * {@code float} and {@code Float}, {@code double} and {@code Double},
+     * {@code BigDecimal}, {@code Map}, {@code List} and {@code Set}.
+     * Otherwise, if true, null will be used as the candidate-value if no
+     * matching value for the specified key-pattern exists in the Redis
+     * database. However, if {@link Redis#forceUpdate()} is false, then a
+     * non-null default field-value will take precedence over a null candidate.
+     */
+    boolean allowNull() default true;
+
+    /**
+     * If true, the retrieved value from the Redis database will always take
+     * precedence (even if it is null) over the default field value.
+     * Otherwise, default field values will take precedence over a null
+     * candidate value (see {@link Redis#allowNull()}).
+     */
+    boolean forceUpdate() default false;
+}

--- a/src/main/java/com/github/strawberry/guice/ConfigMembersInjector.java
+++ b/src/main/java/com/github/strawberry/guice/ConfigMembersInjector.java
@@ -1,0 +1,62 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice;
+
+import java.lang.reflect.Field;
+
+import com.google.common.cache.LoadingCache;
+import com.google.inject.MembersInjector;
+
+import fj.data.Option;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+final class ConfigMembersInjector<T> implements MembersInjector<T> {
+
+    private final LoadingCache<Field, Option> cache;
+    private final Field field;
+
+    ConfigMembersInjector(LoadingCache<Field, Option> cache, Field field) {
+        this.cache = cache;
+        this.field = field;
+        this.field.setAccessible(true);
+    }
+
+    @Override
+    public void injectMembers(final T object) {
+        Option value = this.cache.getUnchecked(this.field);
+        try {
+            Config annotation = this.field.getAnnotation(Config.class);
+            if (this.field.get(object) != null) {
+                // If field is not equal to null (i.e. default value has been set)
+                // and if value to be injected is not null, then set.
+                // Or, if forced update has been specified, then set.
+                if (annotation.forceUpdate() || value.isSome()) {
+                    this.field.set(object, value.toNull());
+                }
+            } else {
+                // Always set null field.
+                this.field.set(object, value.toNull());
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/github/strawberry/guice/ConfigModule.java
+++ b/src/main/java/com/github/strawberry/guice/ConfigModule.java
@@ -28,6 +28,7 @@ import com.google.inject.Module;
 import com.google.inject.matcher.Matchers;
 
 import fj.data.Option;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -107,7 +108,7 @@ public final class ConfigModule extends AbstractModule {
      * {@code JedisPool} of connections to a Redis database. 
      * @param pool The pool of connections to a Redis database.
      */
-    public ConfigModule(Properties properties) {
+    public ConfigModule(Map properties) {
         
         // This constructor would be called in situations where caching of
         // Redis field-values are not important, and the latest most up-to-date

--- a/src/main/java/com/github/strawberry/guice/ConfigModule.java
+++ b/src/main/java/com/github/strawberry/guice/ConfigModule.java
@@ -1,0 +1,126 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice;
+
+import com.github.strawberry.guice.config.ConfigLoader;
+import java.lang.reflect.Field;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.matcher.Matchers;
+
+import fj.data.Option;
+import java.util.Properties;
+
+/**
+ * {@code RedisModule} is responsible for setting up the custom injections that
+ * need to occur for the {@link Redis} field-annotations that may be present in
+ * your classes. You simply need to install this {@link Module} inside your main
+ * Guice {@code Module}, giving it the {@link JedisPool} of connections to your
+ * Redis database as constructor argument. This is illustrated with the
+ * following example:
+ * 
+ * <pre>
+ * public class MyCustomModule extends AbstractModule {
+ *   
+ *   private final JedisPool pool = new JedisPool("localhost", 6379);
+ * 
+ *   {@literal @}Override
+ *   protected void configure() {
+ *     install(new RedisModule(this.pool));
+ *     // set up the rest of your bindings.
+ *     ...
+ *   }
+ * }
+ * </pre>
+ * 
+ * However, this assumes that you don't want any caching to occur for the field
+ * values that are loaded from the Redis database. For more fine-grained control
+ * you can manually provide the {@link LoadingCache} of {@link Field}-to-value
+ * mappings as the following example illustrates:
+ * 
+ * <pre>
+ * public class MyCustomModule extends AbstractModule {
+ *   
+ *   private final JedisPool pool = new JedisPool("localhost", 6379);
+ * 
+ *   {@literal @}Override
+ *   protected void configure() {
+ *     LoadingCache<Field, Option> cache =
+ *       CacheBuilder.newBuilder().
+ *       expireAfterWrite(1, TimeUnit.DAYS).
+ *       maximumSize(1000).
+ *       build(new RedisLoader(this.pool));
+ *     install(new RedisModule(cache));
+ *     // set up the rest of your bindings.
+ *     ...
+ *   }
+ * }
+ * </pre>
+ * 
+ * The abovementioned example will create a cache that stores up to 1000 field
+ * values, and will expire these values after a day before loading them again
+ * from the Redis database. See Google Guava's {@link CacheBuilder} class for
+ * more comprehensive examples on how to construct a customized cache.
+ * <b>Note</b>: the {@code CacheBuilder} requires a {@link CacheLoader} to
+ * actually load the values into the cache if no matching key-value pair could
+ * be found. The class responsible for this is {@link RedisLoader} and contains
+ * the bulk of the logic that pertains to loading and transforming values from
+ * Redis to be used as field-values.
+ * 
+ * @author Wiehann Matthysen
+ */
+public final class ConfigModule extends AbstractModule {
+
+    private final LoadingCache<Field, Option> cache;
+
+    /**
+     * Initializes a newly created {@code RedisModule} with the given cache of
+     * {@code Field}-to-value mappings.
+     * @param cache The cache that will serve as storage for field values that
+     * are loaded from the Redis database.
+     */
+    public ConfigModule(LoadingCache<Field, Option> cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Initializes a newly created {@code RedisModule} with the given
+     * {@code JedisPool} of connections to a Redis database. 
+     * @param pool The pool of connections to a Redis database.
+     */
+    public ConfigModule(Properties properties) {
+        
+        // This constructor would be called in situations where caching of
+        // Redis field-values are not important, and the latest most up-to-date
+        // values should be retrieved from Redis whevever the Injector creates
+        // an object with Redis-annotated fields.
+        
+        // It achieves this by creating a cache that never stores it's values
+        // (maximum size of 0).
+        this.cache = CacheBuilder.newBuilder().maximumSize(0).build(new ConfigLoader(properties));
+    }
+
+    @Override
+    protected void configure() {
+        bindListener(Matchers.any(), new ConfigTypeListener(this.cache));
+    }
+}

--- a/src/main/java/com/github/strawberry/guice/ConfigTypeListener.java
+++ b/src/main/java/com/github/strawberry/guice/ConfigTypeListener.java
@@ -1,0 +1,49 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice;
+
+import java.lang.reflect.Field;
+
+import com.google.common.cache.LoadingCache;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
+import fj.data.Option;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+final class ConfigTypeListener implements TypeListener {
+
+    private final LoadingCache<Field, Option> cache;
+
+    ConfigTypeListener(LoadingCache<Field, Option> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public <T> void hear(TypeLiteral<T> typeLiteral, TypeEncounter<T> typeEncounter) {
+        for (Field field : typeLiteral.getRawType().getDeclaredFields()) {
+            if (field.isAnnotationPresent(Config.class)) {
+                typeEncounter.register(new ConfigMembersInjector<T>(this.cache, field));
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/strawberry/guice/ConversionException.java
+++ b/src/main/java/com/github/strawberry/guice/ConversionException.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
-package com.github.strawberry.redis;
+package com.github.strawberry.guice;
 
 /**
  *
@@ -23,19 +23,19 @@ package com.github.strawberry.redis;
  */
 public final class ConversionException extends RuntimeException {
 
-    ConversionException(String message, Throwable cause) {
+    public ConversionException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    ConversionException(String message) {
+    public ConversionException(String message) {
         super(message);
     }
 
-    static ConversionException of(Exception cause, String toConvert, String key, Class<?> type) {
+    public static ConversionException of(Exception cause, String toConvert, String key, Class<?> type) {
         return new ConversionException(String.format("Cannot convert value: (%s) at key: (%s) to %s.", toConvert, key, type), cause);
     }
 
-    static ConversionException of(String toConvert, String key, Class<?> type) {
+    public static ConversionException of(String toConvert, String key, Class<?> type) {
         return new ConversionException(String.format("Cannot convert value: (%s) at key: (%s) to %s.", toConvert, key, type));
     }
 }

--- a/src/main/java/com/github/strawberry/guice/config/ConfigLoader.java
+++ b/src/main/java/com/github/strawberry/guice/config/ConfigLoader.java
@@ -1,0 +1,250 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConversionException;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.github.strawberry.guice.Redis;
+import com.github.strawberry.redis.RedisLoader;
+import static com.github.strawberry.util.Types.BOOLEAN;
+import static com.github.strawberry.util.Types.TRUE;
+import static com.github.strawberry.util.Types.collectionImplementationOf;
+import static com.github.strawberry.util.Types.genericTypeOf;
+import static com.github.strawberry.util.Types.isAssignableTo;
+import static com.github.strawberry.util.Types.isEqualTo;
+import static com.github.strawberry.util.Types.mapImplementationOf;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.JedisPool;
+
+import fj.data.Option;
+import java.lang.reflect.Type;
+
+import java.util.Properties;
+import redis.clients.jedis.Jedis;
+
+/**
+ * {@code RedisLoader} is used in conjunction with a {@link CacheBuilder} to
+ * construct a {@link Cache} of {@link Field} values. An {@link Injector} uses
+ * these field values during the object-creation phase when setting values for
+ * fields that have been annotated with the {@link Redis}-annotation.
+ * 
+ * @author Wiehann Matthysen
+ */
+public final class ConfigLoader extends CacheLoader<Field, Option> {
+
+    private final Properties properties;
+
+    /**
+     * Internal enum to match against all supported Redis data types.
+     */
+    /**
+     * Initializes a newly created {@code RedisLoader} with the given
+     * {@link JedisPool} to be used as source for connections to a Redis
+     * database.
+     * @param pool The pool of connections to a Redis database.
+     */
+    public ConfigLoader(Properties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public Option load(Field field) throws Exception {
+        return getFromProperties(properties, field, field.getAnnotation(Config.class));
+    }
+
+
+    private static Option getFromProperties(Properties properties, final Field field, final Config annotation) {
+
+        Object value = null;
+        
+        Class<?> fieldType = field.getType();
+
+        String pattern = annotation.value();
+        boolean allowNull = annotation.allowNull();
+
+        Set<String> matchingKeys = getKeys(properties, pattern);
+        if (matchingKeys.size() == 1) {
+            String matchingKey = Iterables.getOnlyElement(matchingKeys);
+            if (fieldType.equals(char[].class)) {
+                value = properties.get(matchingKey).toString().toCharArray();
+            } else if (fieldType.equals(Character[].class)) {
+                value = ArrayUtils.toObject(properties.get(matchingKey).toString().toCharArray());
+            } else if (fieldType.equals(char.class) || fieldType.equals(Character.class)) {
+                String toConvert = properties.get(matchingKey).toString();
+                if (toConvert.length() == 1) {
+                    value = properties.get(matchingKey).toString().charAt(0);
+                } else {
+                    throw ConversionException.of(toConvert, matchingKey, fieldType);
+                }
+            } else if (fieldType.equals(String.class)) {
+                value = properties.get(matchingKey);
+            } else if (fieldType.equals(byte[].class)) {
+                value = properties.get(matchingKey.getBytes());
+            } else if (fieldType.equals(Byte[].class)) {
+                value = ArrayUtils.toObject(properties.get(matchingKey.getBytes()).toString().getBytes());
+            } else if (fieldType.equals(boolean.class) || fieldType.equals(Boolean.class)) {
+                String toConvert = properties.get(matchingKey).toString();
+                if (BOOLEAN.matcher(toConvert).matches()) {
+                    value = TRUE.matcher(toConvert).matches();
+                } else {
+                    throw ConversionException.of(toConvert, matchingKey, fieldType);
+                }
+            } else if (Map.class.isAssignableFrom(fieldType)) {
+                value = mapOf(field, properties, matchingKey);
+            } else if (Collection.class.isAssignableFrom(fieldType)) {
+                value = collectionOf(field, properties, matchingKey);
+            } else {
+                String toConvert = properties.get(matchingKey).toString();
+                try {
+                    if (fieldType.equals(byte.class) || fieldType.equals(Byte.class)) {
+                        value = Byte.parseByte(properties.get(matchingKey).toString());
+                    } else if (fieldType.equals(short.class) || fieldType.equals(Short.class)) {
+                        value = Short.parseShort(toConvert);
+                    } else if (fieldType.equals(int.class) || fieldType.equals(Integer.class)) {
+                        value = Integer.parseInt(toConvert);
+                    } else if (fieldType.equals(long.class) || fieldType.equals(Long.class)) {
+                        value = Long.parseLong(toConvert);
+                    } else if (fieldType.equals(BigInteger.class)) {
+                        value = new BigInteger(toConvert);
+                    } else if (fieldType.equals(float.class) || fieldType.equals(Float.class)) {
+                        value = Float.parseFloat(toConvert);
+                    } else if (fieldType.equals(double.class) || fieldType.equals(Double.class)) {
+                        value = Double.parseDouble(toConvert);
+                    } else if (fieldType.equals(BigDecimal.class)) {
+                        value = new BigDecimal(toConvert);
+                    }
+                } catch (NumberFormatException exception) {
+                    throw ConversionException.of(exception, toConvert, matchingKey, fieldType);
+                }
+            }
+        } else if (matchingKeys.size() > 1) {
+            if (Map.class.isAssignableFrom(fieldType)) {
+                value = nestedMapOf(field, properties, matchingKeys);
+            }
+            else if (Collection.class.isAssignableFrom(fieldType)) {
+                value = nestedCollectionOf(field, properties, matchingKeys);
+            }
+        } else {
+            if (!allowNull) {
+                value = nonNullValueOf(fieldType);
+            }
+        }
+        return Option.fromNull(value);
+    }
+
+    private static Set<String> getKeys(Properties properties, String pattern) {
+        if (properties.containsKey(pattern)) {
+            return Sets.newHashSet(pattern);
+        } else {
+            return Sets.newHashSet();
+        }
+    }
+
+    /**
+     * Utility method to create a default non-null value for the given type
+     * parameter. This gets called when {@link Redis#allowNull()} was set to
+     * false for the given {@link Field}, and no value for the specified key(s)
+     * (see {@link Redis#value()}) was present in the Redis database.
+     * @param type The type to create the non-null value for.
+     * @return A non-null instance of the type. Note: for primitives this will
+     * obviously result in a boxed return value.
+     */
+    private static Object nonNullValueOf(Class<?> type) {
+        Object value = null;
+        if (type.equals(char[].class)) {
+            value = new char[]{};
+        } else if (type.equals(Character[].class)) {
+            value = new Character[]{};
+        } else if (type.equals(char.class) || type.equals(Character.class)) {
+            value = '\0';
+        } else if (type.equals(String.class)) {
+            value = "";
+        } else if (type.equals(byte[].class)) {
+            value = new byte[]{};
+        } else if (type.equals(Byte[].class)) {
+            value = new Byte[]{};
+        } else if (type.equals(byte.class) || type.equals(Byte.class)) {
+            value = (byte)0;
+        } else if (type.equals(boolean.class) || type.equals(Boolean.class)) {
+            value = false;
+        } else if (type.equals(short.class) || type.equals(Short.class)) {
+            value = (short)0;
+        } else if (type.equals(int.class) || type.equals(Integer.class)) {
+            value = 0;
+        } else if (type.equals(long.class) || type.equals(Long.class)) {
+            value = 0L;
+        } else if (type.equals(BigInteger.class)) {
+            value = BigInteger.ZERO;
+        } else if (type.equals(float.class) || type.equals(Float.class)) {
+            value = 0.0f;
+        } else if (type.equals(double.class) || type.equals(Double.class)) {
+            value = 0.0;
+        } else if (type.equals(BigDecimal.class)) {
+            value = BigDecimal.ZERO;
+        } else if (Map.class.isAssignableFrom(type)) {
+            value = mapImplementationOf(type);
+        } else if (Collection.class.isAssignableFrom(type)) {
+            value = collectionImplementationOf(type);
+        }
+        return value;
+    }
+
+    private static Map<?, ?> nestedMapOf(Field field, Properties properties, Set<String> redisKeys) {
+        Map map = mapImplementationOf(field.getType());
+        for (String redisKey : redisKeys) {
+            map.put(redisKey, properties.get(redisKey));
+        }
+        return map;
+    }
+
+    private static Collection<?> nestedCollectionOf(Field field, Properties properties, Set<String> redisKeys) {
+        Collection collection = collectionImplementationOf(field.getType());
+        for (String redisKey : redisKeys) {
+            collection.add(properties.get(redisKey));
+        }
+        return collection;
+    }
+    
+    private static Map<?, ?> mapOf(Field field, Properties properties, String key) {
+        Map map = mapImplementationOf(field.getType());
+        map.put(key, properties.get(key));
+        return map;
+    }
+
+    private static Collection<?> collectionOf(Field field, Properties properties, String key) {
+        Collection collection = collectionImplementationOf(field.getType());
+        collection.add(properties.get(key));
+        return collection;
+    }
+
+}

--- a/src/main/java/com/github/strawberry/guice/config/ConfigLoader.java
+++ b/src/main/java/com/github/strawberry/guice/config/ConfigLoader.java
@@ -109,9 +109,13 @@ public final class ConfigLoader extends CacheLoader<Field, Option> {
             } else if (fieldType.equals(String.class)) {
                 value = properties.get(matchingKey);
             } else if (fieldType.equals(byte[].class)) {
-                value = properties.get(matchingKey.getBytes());
+                if (properties.containsKey(matchingKey)) {
+                    value = properties.get(matchingKey).toString().getBytes();
+                } else {
+                    value = null;
+                }
             } else if (fieldType.equals(Byte[].class)) {
-                value = ArrayUtils.toObject(properties.get(matchingKey.getBytes()).toString().getBytes());
+                value = ArrayUtils.toObject(properties.get(matchingKey).toString().getBytes());
             } else if (fieldType.equals(boolean.class) || fieldType.equals(Boolean.class)) {
                 String toConvert = properties.get(matchingKey).toString();
                 if (BOOLEAN.matcher(toConvert).matches()) {

--- a/src/main/java/com/github/strawberry/guice/config/ConfigLoader.java
+++ b/src/main/java/com/github/strawberry/guice/config/ConfigLoader.java
@@ -41,6 +41,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Injector;
 
@@ -247,8 +248,13 @@ public final class ConfigLoader extends CacheLoader<Field, Option> {
 
     private static Collection<?> collectionOf(Field field, Properties properties, String key) {
         Collection collection = collectionImplementationOf(field.getType());
-        collection.add(properties.get(key));
-        return collection;
+        Object list = properties.get(key);
+        if (list != null) {
+            collection.addAll(Lists.newArrayList(properties.get(key).toString().split(",")));
+            return collection;
+        } else {
+            return collection;
+        }
     }
 
 }

--- a/src/main/java/com/github/strawberry/redis/RedisLoader.java
+++ b/src/main/java/com/github/strawberry/redis/RedisLoader.java
@@ -17,6 +17,7 @@
  */
 package com.github.strawberry.redis;
 
+import com.github.strawberry.guice.ConversionException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;

--- a/src/main/java/com/github/strawberry/util/Json.java
+++ b/src/main/java/com/github/strawberry/util/Json.java
@@ -1,6 +1,19 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 package com.github.strawberry.util;
 

--- a/src/main/java/com/github/strawberry/util/Json.java
+++ b/src/main/java/com/github/strawberry/util/Json.java
@@ -1,0 +1,81 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.strawberry.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ * @author nicok
+ */
+public class Json {
+    static JsonParser parser = new JsonParser();
+
+    public static Object parsePrimitive(JsonElement e) {
+        JsonPrimitive p = e.getAsJsonPrimitive();
+        if (p.isString()) {
+            return e.getAsString();
+        }
+        if (p.isBoolean()) {
+            return e.getAsBoolean();
+        }
+        if (p.isNumber()) {
+            return e.getAsInt();
+        }
+        return p.getAsString();
+    }
+    public static Collection parseArray(String json) {
+        JsonArray o = (JsonArray)parser.parse(json);
+        Collection c = Lists.newArrayList();
+        for (JsonElement value : o) {
+            if (!value.isJsonPrimitive()) {
+                if (value.isJsonArray()) {
+                    c.add(parseArray(value.toString()));
+                } else if (value.isJsonObject()) {
+                    c.add(parse(value.toString()));
+                }
+
+            } else {
+                c.add(parsePrimitive(value));
+
+            }
+        }
+        return c;
+    }
+    public static Map<String, Object> parse(String json) {
+        JsonObject o = (JsonObject)parser.parse(json);
+        Set<Map.Entry<String,JsonElement>> set = o.entrySet();
+        Map<String,Object> map = Maps.newHashMap();
+        for (Map.Entry<String,JsonElement> e : set) {
+            String key = e.getKey();
+            JsonElement value = e.getValue();
+            if (!value.isJsonPrimitive()) {
+                if (value.isJsonObject()) {
+                    map.put(key, parse(value.toString()));
+
+                } else if (value.isJsonArray()) {
+                    map.put(key, parseArray(value.toString()));
+
+                }
+            } else {
+                map.put(key, parsePrimitive(value));
+            }
+            
+        }
+        return map;
+
+    }
+
+    
+}

--- a/src/test/java/com/github/strawberry/guice/config/AggregateInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/AggregateInjectionTest.java
@@ -1,0 +1,1410 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class AggregateInjectionTest extends AbstractModule {
+    
+    Properties properties = new Properties();
+    private Injector injector;
+    
+    @Override
+    protected void configure() {
+        install(new ConfigModule(properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+        properties.clear();
+    }
+
+    @After
+    public void teardown() {
+    }
+    
+    
+    
+    public static class StringsInListContainer {
+        
+        @Config("test:string:*")
+        private List<String> injectedStrings;
+        
+        public List<String> getInjectedStrings() {
+            return this.injectedStrings;
+        }
+    }
+    
+    public static class StringsInListDefaultValueContainer {
+        
+        @Config("test:string:*")
+        private List<String> injectedStrings = ImmutableList.of(
+            "value_01", "value_02", "value_03");
+        
+        public List<String> getInjectedStrings() {
+            return this.injectedStrings;
+        }
+    }
+    
+    @Test
+    public void test_that_strings_are_injected_into_list() {
+        String testString = "test_value:%s";
+        List<String> expectedList = Lists.newArrayList();
+        for (int i = 0; i < 10; ++i) {
+            properties.put(String.format("test:string:%s", i), String.format(testString, i));
+            expectedList.add(String.format(testString, i));
+        }
+        StringsInListContainer dummy = this.injector.getInstance(StringsInListContainer.class);
+        assertThat(Sets.newHashSet(dummy.getInjectedStrings()), is(equalTo(Sets.newHashSet(expectedList))));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list() {
+        // Test for case where no value is present in redis database.
+        StringsInListDefaultValueContainer dummy = this.injector.getInstance(
+            StringsInListDefaultValueContainer.class);
+        List<String> defaultList = ImmutableList.of("value_01", "value_02", "value_03");
+        assertThat(dummy.getInjectedStrings(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        String testString = "test_value:%s";
+        List<String> expectedList = Lists.newArrayList();
+        for (int i = 0; i < 10; ++i) {
+            properties.put(String.format("test:string:%s", i), String.format(testString, i));
+            expectedList.add(String.format(testString, i));
+        }
+        dummy = this.injector.getInstance(StringsInListDefaultValueContainer.class);
+        assertThat(Sets.newHashSet(dummy.getInjectedStrings()), is(equalTo(Sets.newHashSet(expectedList))));
+    }
+    
+    
+    
+    public static class StringsInMapContainer {
+        
+        @Config("test:string:*")
+        private Map<String, String> injectedStrings;
+        
+        public Map<String, String> getInjectedStrings() {
+            return this.injectedStrings;
+        }
+    }
+    
+    public static class StringsInMapDefaultValueContainer {
+        
+        @Config("test:string:*")
+        private Map<String, String> injectedStrings = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        
+        public Map<String, String> getInjectedStrings() {
+            return this.injectedStrings;
+        }
+    }
+    
+    @Test
+    public void test_that_strings_are_injected_into_map() {
+        String testString = "test_value:%s";
+        Map<String, String> expectedMap = Maps.newLinkedHashMap();
+        for (int i = 0; i < 10; ++i) {
+            properties.put(String.format("test:string:%s", i), String.format(testString, i));
+            expectedMap.put(String.format("test:string:%s", i), String.format(testString, i));
+        }
+        StringsInMapContainer dummy = this.injector.getInstance(StringsInMapContainer.class);
+        assertThat(dummy.getInjectedStrings(), is(equalTo(expectedMap)));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map() {
+        // Test for case where no value is present in redis database.
+        StringsInMapDefaultValueContainer dummy = this.injector.getInstance(
+            StringsInMapDefaultValueContainer.class);
+        Map<String, String> defaultMap = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        assertThat(dummy.getInjectedStrings(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        String testString = "test_value:%s";
+        Map<String, String> expectedMap = Maps.newLinkedHashMap();
+        for (int i = 0; i < 10; ++i) {
+            properties.put(String.format("test:string:%s", i), String.format(testString, i));
+            expectedMap.put(String.format("test:string:%s", i), String.format(testString, i));
+        }
+        dummy = this.injector.getInstance(StringsInMapDefaultValueContainer.class);
+        assertThat(dummy.getInjectedStrings(), is(equalTo(expectedMap)));
+    }
+    
+    
+    
+    public static class MapsInListContainer {
+        
+        @Config("test:map:*")
+        private List<Map<String, String>> injectedMaps;
+        
+        public List<Map<String, String>> getInjectedMaps() {
+            return this.injectedMaps;
+        }
+    }
+    
+    public static class MapsInListDefaultValueContainer {
+        
+        @Config("test:map:*")
+        private List<Map<String, String>> injectedMaps = (List)ImmutableList.of(
+            ImmutableMap.of(
+                "key_11", "value_11",
+                "key_12", "value_12",
+                "key_13", "value_13"
+            ),
+            ImmutableMap.of(
+                "key_21", "value_21",
+                "key_22", "value_22",
+                "key_23", "value_23"
+            )
+        );
+        
+        public List<Map<String, String>> getInjectedMaps() {
+            return this.injectedMaps;
+        }
+    }
+    
+    @Test
+    public void test_that_maps_are_injected_into_list_of_map() {
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:map:%s", i), testMap);
+        }
+        MapsInListContainer dummy = this.injector.getInstance(MapsInListContainer.class);
+        List<Map<String, String>> actualMaps = dummy.getInjectedMaps();
+        assertThat(actualMaps.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualMaps.contains(expectedMap), is(true));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list_of_map() {
+        // Test for case where no value is present in redis database.
+        MapsInListDefaultValueContainer dummy = this.injector.getInstance(
+            MapsInListDefaultValueContainer.class);
+        List<Map<String, String>> defaultList = (List)ImmutableList.of(
+            ImmutableMap.of(
+                "key_11", "value_11",
+                "key_12", "value_12",
+                "key_13", "value_13"
+            ),
+            ImmutableMap.of(
+                "key_21", "value_21",
+                "key_22", "value_22",
+                "key_23", "value_23"
+            )
+        );
+        assertThat(dummy.getInjectedMaps(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:map:%s", i), testMap);
+        }
+        dummy = this.injector.getInstance(MapsInListDefaultValueContainer.class);
+        List<Map<String, String>> actualMaps = dummy.getInjectedMaps();
+        assertThat(actualMaps.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualMaps.contains(expectedMap), is(true));
+        }
+    }
+    
+    
+    
+    public static class MapsInMapContainer {
+        
+        @Config("test:map:*")
+        private Map<String, Map<String, String>> injectedMaps;
+        
+        public Map<String, Map<String, String>> getInjectedMaps() {
+            return this.injectedMaps;
+        }
+    }
+    
+    public static class MapsInMapDefaultValueContainer {
+        
+        @Config("test:map:*")
+        private Map<String, Map<String, String>> injectedMaps = (Map)ImmutableMap.of(
+            "test_map_01", ImmutableMap.of(
+                "key_11", "value_11",
+                "key_12", "value_12",
+                "key_13", "value_13"
+            ),
+            "test_map_02", ImmutableMap.of(
+                "key_21", "value_21",
+                "key_22", "value_22",
+                "key_23", "value_23"
+            )
+        );
+        
+        public Map<String, Map<String, String>> getInjectedMaps() {
+            return this.injectedMaps;
+        }
+    }
+    
+    @Test
+    public void test_that_maps_are_injected_into_map_of_map() {
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:map:%s", i), testMap);
+        }
+        MapsInMapContainer dummy = this.injector.getInstance(MapsInMapContainer.class);
+        Map<String, Map<String, String>> actualMaps = dummy.getInjectedMaps();
+        assertThat(actualMaps.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualMaps.get(String.format("test:map:%s", i)), is(equalTo(expectedMap)));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map_of_map() {
+        // Test for case where no value is present in redis database.
+        MapsInMapDefaultValueContainer dummy = this.injector.getInstance(
+            MapsInMapDefaultValueContainer.class);
+        Map<String, Map<String, String>> defaultMap = (Map)ImmutableMap.of(
+            "test_map_01", ImmutableMap.of(
+                "key_11", "value_11",
+                "key_12", "value_12",
+                "key_13", "value_13"
+            ),
+            "test_map_02", ImmutableMap.of(
+                "key_21", "value_21",
+                "key_22", "value_22",
+                "key_23", "value_23"
+            )
+        );
+        assertThat(dummy.getInjectedMaps(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:map:%s", i), testMap);
+        }
+        dummy = this.injector.getInstance(MapsInMapDefaultValueContainer.class);
+        Map<String, Map<String, String>> actualMaps = dummy.getInjectedMaps();
+        assertThat(actualMaps.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualMaps.get(String.format("test:map:%s", i)), is(equalTo(expectedMap)));
+        }
+    }
+    
+    
+    
+    public static class ListsInListContainer {
+        
+        @Config("test:list:*")
+        private List<List<String>> injectedLists;
+        
+        public List<List<String>> getInjectedLists() {
+            return this.injectedLists;
+        }
+    }
+    
+    public static class ListsInListDefaultValueContainer {
+        
+        @Config("test:list:*")
+        private List<List<String>> injectedLists = (List)ImmutableList.of(
+            ImmutableList.of("value_11", "value_12", "value_13"),
+            ImmutableList.of("value_21", "value_22", "value_23")
+        );
+        
+        public List<List<String>> getInjectedLists() {
+            return this.injectedLists;
+        }
+    }
+   
+    private void rpush(Map m, String key, String val) {
+        if (!m.containsKey(key)) {
+            m.put(key,Lists.newArrayList());
+        }
+        ((List)m.get(key)).add(val);
+    }
+
+    private void sadd(Map m, String key, String val) {
+        if (!m.containsKey(key)) {
+            m.put(key,Sets.newHashSet());
+        }
+        ((Set)m.get(key)).add(val);
+    }
+    private void zadd(Map m, String key, int i, String val) {
+        if (!m.containsKey(key)) {
+            m.put(key,Sets.newLinkedHashSet());
+        }
+        ((Set)m.get(key)).add(val);
+    }
+    @Test
+    public void test_that_lists_are_injected_into_list_of_list() {
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:list:%s", i), String.format(testValue, i));
+            }
+        }
+        ListsInListContainer dummy = this.injector.getInstance(ListsInListContainer.class);
+        List<List<String>> actualLists = dummy.getInjectedLists();
+        assertThat(actualLists.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualLists.contains(expectedList), is(true));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list_of_list() {
+        // Test for case where no value is present in redis database.
+        ListsInListDefaultValueContainer dummy = this.injector.getInstance(
+            ListsInListDefaultValueContainer.class);
+        List<List<String>> defaultList = (List)ImmutableList.of(
+            ImmutableList.of("value_11", "value_12", "value_13"),
+            ImmutableList.of("value_21", "value_22", "value_23")
+        );
+        assertThat(dummy.getInjectedLists(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:list:%s", i), String.format(testValue, i));
+            }
+        }
+        dummy = this.injector.getInstance(ListsInListDefaultValueContainer.class);
+        List<List<String>> actualLists = dummy.getInjectedLists();
+        assertThat(actualLists.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualLists.contains(expectedList), is(true));
+        }
+    }
+    
+    
+    
+    public static class ListsInMapContainer {
+        
+        @Config("test:list:*")
+        private Map<String, List<String>> injectedLists;
+        
+        public Map<String, List<String>> getInjectedLists() {
+            return this.injectedLists;
+        }
+    }
+    
+    public static class ListsInMapDefaultValueContainer {
+        
+        @Config("test:list:*")
+        private Map<String, List<String>> injectedLists = (Map)ImmutableMap.of(
+            "test_list_01", ImmutableList.of(
+                "value_11", "value_12", "value_13"
+            ),
+            "test_list_02", ImmutableList.of(
+                "value_21", "value_22", "value_23"
+            )
+        );
+        
+        public Map<String, List<String>> getInjectedLists() {
+            return this.injectedLists;
+        }
+    }
+    
+    @Test
+    public void test_that_lists_are_injected_into_map_of_list() {
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:list:%s", i), String.format(testValue, i));
+            }
+        }
+        ListsInMapContainer dummy = this.injector.getInstance(ListsInMapContainer.class);
+        Map<String, List<String>> actualLists = dummy.getInjectedLists();
+        assertThat(actualLists.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualLists.get(String.format("test:list:%s", i)), is(equalTo(expectedList)));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map_of_list() {
+        // Test for case where no value is present in redis database.
+        ListsInMapDefaultValueContainer dummy = this.injector.getInstance(
+            ListsInMapDefaultValueContainer.class);
+        Map<String, List<String>> defaultMap = (Map)ImmutableMap.of(
+            "test_list_01", ImmutableList.of(
+                "value_11", "value_12", "value_13"
+            ),
+            "test_list_02", ImmutableList.of(
+                "value_21", "value_22", "value_23"
+            )
+        );
+        assertThat(dummy.getInjectedLists(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:list:%s", i), String.format(testValue, i));
+            }
+        }
+        dummy = this.injector.getInstance(ListsInMapDefaultValueContainer.class);
+        Map<String, List<String>> actualLists = dummy.getInjectedLists();
+        assertThat(actualLists.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualLists.get(String.format("test:list:%s", i)), is(equalTo(expectedList)));
+        }
+    }
+    
+    
+    
+    public static class SetsInListContainer {
+        
+        @Config("test:set:*")
+        private List<Set<String>> injectedSets;
+        
+        public List<Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    public static class SetsInListDefaultValueContainer {
+        
+        @Config("test:set:*")
+        private List<Set<String>> injectedSets = (List)ImmutableList.of(
+            Sets.newHashSet("value_11", "value_12", "value_13"),
+            Sets.newHashSet("value_21", "value_22", "value_23")
+        );
+        
+        public List<Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    @Test
+    public void test_that_sets_are_injected_into_list_of_set() {
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:set:%s", i), String.format(testValue, i));
+            }
+        }
+        SetsInListContainer dummy = this.injector.getInstance(SetsInListContainer.class);
+        List<Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualSets.contains(expectedSet), is(true));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list_of_set() {
+        // Test for case where no value is present in redis database.
+        SetsInListDefaultValueContainer dummy = this.injector.getInstance(
+            SetsInListDefaultValueContainer.class);
+        List<Set<String>> defaultList = (List)ImmutableList.of(
+            Sets.newHashSet("value_11", "value_12", "value_13"),
+            Sets.newHashSet("value_21", "value_22", "value_23")
+        );
+        assertThat(dummy.getInjectedSets(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:set:%s", i), String.format(testValue, i));
+            }
+        }
+        dummy = this.injector.getInstance(SetsInListDefaultValueContainer.class);
+        List<Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualSets.contains(expectedSet), is(true));
+        }
+    }
+
+    
+    
+    public static class SetsInMapContainer {
+        
+        @Config("test:set:*")
+        private Map<String, Set<String>> injectedSets;
+        
+        public Map<String, Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    public static class SetsInMapDefaultValueContainer {
+        
+        @Config("test:set:*")
+        private Map<String, Set<String>> injectedSets = (Map)ImmutableMap.of(
+            "test_set_01", Sets.newHashSet(
+                "value_11", "value_12", "value_13"
+            ),
+            "test_set_02", Sets.newHashSet(
+                "value_21", "value_22", "value_23"
+            )
+        );
+        
+        public Map<String, Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    @Test
+    public void test_that_sets_are_injected_into_map_of_set() {
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:set:%s", i), String.format(testValue, i));
+            }
+        }
+        SetsInMapContainer dummy = this.injector.getInstance(SetsInMapContainer.class);
+        Map<String, Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualSets.get(String.format("test:set:%s", i)), is(equalTo(expectedSet)));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map_of_set() {
+        // Test for case where no value is present in redis database.
+        SetsInMapDefaultValueContainer dummy = this.injector.getInstance(
+            SetsInMapDefaultValueContainer.class);
+        Map<String, Set<String>> defaultMap = (Map)ImmutableMap.of(
+            "test_set_01", Sets.newHashSet(
+                "value_11", "value_12", "value_13"
+            ),
+            "test_set_02", Sets.newHashSet(
+                "value_21", "value_22", "value_23"
+            )
+        );
+        assertThat(dummy.getInjectedSets(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:set:%s", i), String.format(testValue, i));
+            }
+        }
+        dummy = this.injector.getInstance(SetsInMapDefaultValueContainer.class);
+        Map<String, Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i)
+            );
+            assertThat(actualSets.get(String.format("test:set:%s", i)), is(equalTo(expectedSet)));
+        }
+    }
+    
+    
+    
+    public static class OrderedSetsInListContainer {
+        
+        @Config("test:zset:*")
+        private List<Set<String>> injectedSets;
+        
+        public List<Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    public static class OrderedSetsInListDefaultValueContainer {
+        
+        @Config("test:zset:*")
+        private List<Set<String>> injectedSets = (List)ImmutableList.of(
+            Sets.newLinkedHashSet(Lists.newArrayList("value_11", "value_12", "value_13")),
+            Sets.newLinkedHashSet(Lists.newArrayList("value_21", "value_22", "value_23"))
+        );
+        
+        public List<Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    @Test
+    public void test_that_ordered_sets_are_injected_into_list_of_set() {
+        List<String> testList = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                zadd(properties, String.format("test:zset:%s", i), i, String.format(testValue, i));
+            }
+        }
+        OrderedSetsInListContainer dummy = this.injector.getInstance(OrderedSetsInListContainer.class);
+        List<Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualSets.contains(expectedSet), is(true));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list_of_zset() {
+        // Test for case where no value is present in redis database.
+        OrderedSetsInListDefaultValueContainer dummy = this.injector.getInstance(
+            OrderedSetsInListDefaultValueContainer.class);
+        List<Set<String>> defaultList = (List)ImmutableList.of(
+            Sets.newLinkedHashSet(Lists.newArrayList("value_11", "value_12", "value_13")),
+            Sets.newLinkedHashSet(Lists.newArrayList("value_21", "value_22", "value_23"))
+        );
+        assertThat(dummy.getInjectedSets(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        List<String> testList = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                zadd(properties, String.format("test:zset:%s", i), i, String.format(testValue, i));
+            }
+        }
+        dummy = this.injector.getInstance(OrderedSetsInListDefaultValueContainer.class);
+        List<Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualSets.contains(expectedSet), is(true));
+        }
+    }
+    
+    
+    
+    public static class OrderedSetsInMapContainer {
+        
+        @Config("test:zset:*")
+        private Map<String, Set<String>> injectedSets;
+        
+        public Map<String, Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    public static class OrderedSetsInMapDefaultValueContainer {
+        
+        @Config("test:zset:*")
+        private Map<String, Set<String>> injectedSets = (Map)ImmutableMap.of(
+            "test_set_01", Sets.newLinkedHashSet(
+                Lists.newArrayList("value_11", "value_12", "value_13")
+            ),
+            "test_set_02", Sets.newLinkedHashSet(
+                Lists.newArrayList("value_21", "value_22", "value_23")
+            )
+        );
+        
+        public Map<String, Set<String>> getInjectedSets() {
+            return this.injectedSets;
+        }
+    }
+    
+    @Test
+    public void test_that_ordered_sets_are_injected_into_map_of_set() {
+        List<String> testList = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                zadd(properties, String.format("test:zset:%s", i), i, String.format(testValue, i));
+            }
+        }
+        OrderedSetsInMapContainer dummy = this.injector.getInstance(OrderedSetsInMapContainer.class);
+        Map<String, Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualSets.get(String.format("test:zset:%s", i)), is(equalTo(expectedSet)));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map_of_zset() {
+        // Test for case where no value is present in redis database.
+        OrderedSetsInMapDefaultValueContainer dummy = this.injector.getInstance(
+            OrderedSetsInMapDefaultValueContainer.class);
+        Map<String, Set<String>> defaultMap = (Map)ImmutableMap.of(
+            "test_set_01", Sets.newLinkedHashSet(
+                Lists.newArrayList("value_11", "value_12", "value_13")
+            ),
+            "test_set_02", Sets.newLinkedHashSet(
+                Lists.newArrayList("value_21", "value_22", "value_23")
+            )
+        );
+        assertThat(dummy.getInjectedSets(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        List<String> testList = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 0; i < 10; ++i) {
+            for (String testValue : testList) {
+                zadd(properties, String.format("test:zset:%s", i), i, String.format(testValue, i));
+            }
+        }
+        dummy = this.injector.getInstance(OrderedSetsInMapDefaultValueContainer.class);
+        Map<String, Set<String>> actualSets = dummy.getInjectedSets();
+        assertThat(actualSets.size(), is(10));
+        for (int i = 0; i < 10; ++i) {
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualSets.get(String.format("test:zset:%s", i)), is(equalTo(expectedSet)));
+        }
+    }
+    
+    
+    
+    public static class HeterogeneousInListContainer {
+        
+        @Config("test:heterogeneous:*")
+        private List<Object> injectedObjects;
+        
+        public List<Object> getInjectedObjects() {
+            return this.injectedObjects;
+        }
+    }
+    
+    public static class HeterogeneousInListDefaultValueContainer {
+        
+        @Config("test:heterogeneous:*")
+        private List<Object> injectedObjects = (List)Lists.newArrayList(
+            "value_01", "value_02", "value_03",
+            ImmutableMap.of(
+                "key_01", "value_01",
+                "key_02", "value_02",
+                "key_03", "value_03"
+            ),
+            ImmutableList.of("value_01", "value_02", "value_03"),
+            Sets.newHashSet("value_01", "value_02", "value_03"),
+            Sets.newLinkedHashSet(Lists.newArrayList("value_01", "value_02", "value_03"))
+        );
+        
+        public List<Object> getInjectedObjects() {
+            return this.injectedObjects;
+        }
+    }
+    
+    @Test
+    public void test_that_list_is_injected_into_list_of_objects() {
+        // Test list.
+        List<String> testList = Lists.newArrayList("value_1", "value_2", "value_3");
+        for (String testValue : testList) {
+            rpush(properties, "test:heterogeneous:1", testValue);
+        }
+        
+        // Nested list should match expected list.
+        HeterogeneousInListContainer dummy = this.injector.getInstance(HeterogeneousInListContainer.class);
+        List<Object> actualObjects = dummy.getInjectedObjects();
+        assertThat(actualObjects.size(), is(1));
+        assertThat((List<String>)actualObjects.get(0), is(equalTo(testList)));
+    }
+    
+    @Test
+    public void test_that_objects_are_injected_into_list_of_objects() {
+        // Inject some strings.
+        for (int i = 0; i < 3; ++i) {
+            properties.put(String.format("test:heterogeneous:%s", i), String.format("test_value:%s", i));
+        }
+        
+        // Inject some maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:heterogeneous:%s", i), testMap);
+        }
+        
+        // Inject some lists.
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 6; i < 9; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some sets.
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 9; i < 12; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some ordered sets.
+        List<String> testOrderedSet = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 12; i < 15; ++i) {
+            for (String testValue : testOrderedSet) {
+                zadd(properties, String.format("test:heterogeneous:%s", i), i, String.format(testValue, i));
+            }
+        }
+        
+        HeterogeneousInListContainer dummy = this.injector.getInstance(HeterogeneousInListContainer.class);
+        List<Object> actualObjects = dummy.getInjectedObjects();
+        assertThat(actualObjects.size(), is(15));
+        
+        // Test strings.
+        for (int i = 0; i < 3; ++i) {
+            assertThat(actualObjects.contains(String.format("test_value:%s", i)), is(true));
+        }
+        
+        // Test maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualObjects.contains(expectedMap), is(true));
+        }
+        
+        // Test lists.
+        for (int i = 6; i < 9; ++i) {
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualObjects.contains(expectedList), is(true));
+        }
+        
+        // Test sets.
+        for (int i = 9; i < 12; ++i) {
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualObjects.contains(expectedSet), is(true));
+        }
+        
+        // Test ordered sets.
+        for (int i = 12; i < 15; ++i) {
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualObjects.contains(expectedSet), is(true));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list_of_objects() {
+        // Test for case where no value is present in redis database.
+        HeterogeneousInListDefaultValueContainer dummy = this.injector.getInstance(
+            HeterogeneousInListDefaultValueContainer.class);
+        List<Object> defaultList = (List)Lists.newArrayList(
+            "value_01", "value_02", "value_03",
+            ImmutableMap.of(
+                "key_01", "value_01",
+                "key_02", "value_02",
+                "key_03", "value_03"
+            ),
+            ImmutableList.of("value_01", "value_02", "value_03"),
+            Sets.newHashSet("value_01", "value_02", "value_03"),
+            Sets.newLinkedHashSet(Lists.newArrayList("value_01", "value_02", "value_03"))
+        );
+        assertThat(dummy.getInjectedObjects(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        // Inject some strings.
+        for (int i = 0; i < 3; ++i) {
+            properties.put(String.format("test:heterogeneous:%s", i), String.format("test_value:%s", i));
+        }
+        
+        // Inject some maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:heterogeneous:%s", i), testMap);
+        }
+        
+        // Inject some lists.
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 6; i < 9; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some sets.
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 9; i < 12; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some ordered sets.
+        List<String> testOrderedSet = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 12; i < 15; ++i) {
+            for (String testValue : testOrderedSet) {
+                zadd(properties, String.format("test:heterogeneous:%s", i), i, String.format(testValue, i));
+            }
+        }
+        
+        dummy = this.injector.getInstance(HeterogeneousInListDefaultValueContainer.class);
+        List<Object> actualObjects = dummy.getInjectedObjects();
+        assertThat(actualObjects.size(), is(15));
+        
+        // Test strings.
+        for (int i = 0; i < 3; ++i) {
+            assertThat(actualObjects.contains(String.format("test_value:%s", i)), is(true));
+        }
+        
+        // Test maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualObjects.contains(expectedMap), is(true));
+        }
+        
+        // Test lists.
+        for (int i = 6; i < 9; ++i) {
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualObjects.contains(expectedList), is(true));
+        }
+        
+        // Test sets.
+        for (int i = 9; i < 12; ++i) {
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualObjects.contains(expectedSet), is(true));
+        }
+        
+        // Test ordered sets.
+        for (int i = 12; i < 15; ++i) {
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualObjects.contains(expectedSet), is(true));
+        }
+    }
+    
+    
+    
+    public static class HeterogeneousInMapContainer {
+        
+        @Config("test:heterogeneous:*")
+        private Map<String, Object> injectedObjects;
+        
+        public Map<String, Object> getInjectedObjects() {
+            return this.injectedObjects;
+        }
+    }
+    
+    public static class HeterogeneousInMapDefaultValueContainer {
+        
+        @Config("test:heterogeneous:*")
+        private Map<String, Object> injectedObjects = (Map)ImmutableMap.of(
+            "test_string", "test_value",
+            "test_map", ImmutableMap.of(
+                "key_01", "value_01",
+                "key_02", "value_02",
+                "key_03", "value_03"
+            ),
+            "test_list", ImmutableList.of("value_01", "value_02", "value_03"),
+            "test_set",  Sets.newHashSet("value_01", "value_02", "value_03"),
+            "test_zset", Sets.newLinkedHashSet(Lists.newArrayList("value_01", "value_02", "value_03"))
+        );
+        
+        public Map<String, Object> getInjectedObjects() {
+            return this.injectedObjects;
+        }
+    }
+    
+    @Test
+    public void test_that_map_is_injected_into_map_of_objects() {
+        // Test map.
+        Map<String, String> testMap = ImmutableMap.of(
+            "key_1", "value_1",
+            "key_2", "value_2",
+            "key_3", "value_3"
+        );
+        properties.put("test:heterogeneous:1", testMap);
+        
+        // Nested map should match expected map.
+        HeterogeneousInMapContainer dummy = this.injector.getInstance(HeterogeneousInMapContainer.class);
+        Map<String, Object> actualObjects = dummy.getInjectedObjects();
+        assertThat(actualObjects.size(), is(1));
+        assertThat((Map<String, String>)actualObjects.get("test:heterogeneous:1"), is(equalTo(testMap)));
+    }
+    
+    @Test
+    public void test_that_objects_are_injected_into_map_of_objects() {
+        // Inject some strings.
+        for (int i = 0; i < 3; ++i) {
+            properties.put(String.format("test:heterogeneous:%s", i), String.format("test_value:%s", i));
+        }
+        
+        // Inject some maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:heterogeneous:%s", i), testMap);
+        }
+        
+        // Inject some lists.
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 6; i < 9; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some sets.
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 9; i < 12; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some ordered sets.
+        List<String> testOrderedSet = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 12; i < 15; ++i) {
+            for (String testValue : testOrderedSet) {
+                zadd(properties, String.format("test:heterogeneous:%s", i), i, String.format(testValue, i));
+            }
+        }
+        
+        HeterogeneousInMapContainer dummy = this.injector.getInstance(HeterogeneousInMapContainer.class);
+        Map<String, Object> actualObjects = dummy.getInjectedObjects();
+        assertThat(actualObjects.size(), is(15));
+        
+        // Test strings.
+        for (int i = 0; i < 3; ++i) {
+            String actualString = (String)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            assertThat(actualString, is(equalTo(String.format("test_value:%s", i))));
+        }
+        
+        // Test maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> actualMap = (Map)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualMap, is(equalTo(expectedMap)));
+        }
+        
+        // Test lists.
+        for (int i = 6; i < 9; ++i) {
+            List<String> actualList = (List)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualList, is(equalTo(expectedList)));
+        }
+        
+        // Test sets.
+        for (int i = 9; i < 12; ++i) {
+            Set<String> actualSet = (Set)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualSet, is(equalTo(expectedSet)));
+        }
+        
+        // Test ordered sets.
+        for (int i = 12; i < 15; ++i) {
+            Set<String> actualSet = (Set)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualSet, is(equalTo(expectedSet)));
+        }
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map_of_objects() {
+        // Test for case where no value is present in redis database.
+        HeterogeneousInMapDefaultValueContainer dummy = this.injector.getInstance(
+            HeterogeneousInMapDefaultValueContainer.class);
+        Map<String, Object> defaultMap = (Map)ImmutableMap.of(
+            "test_string", "test_value",
+            "test_map", ImmutableMap.of(
+                "key_01", "value_01",
+                "key_02", "value_02",
+                "key_03", "value_03"
+            ),
+            "test_list", ImmutableList.of("value_01", "value_02", "value_03"),
+            "test_set",  Sets.newHashSet("value_01", "value_02", "value_03"),
+            "test_zset", Sets.newLinkedHashSet(Lists.newArrayList("value_01", "value_02", "value_03"))
+        );
+        assertThat(dummy.getInjectedObjects(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        // Inject some strings.
+        for (int i = 0; i < 3; ++i) {
+            properties.put(String.format("test:heterogeneous:%s", i), String.format("test_value:%s", i));
+        }
+        
+        // Inject some maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> testMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            properties.put(String.format("test:heterogeneous:%s", i), testMap);
+        }
+        
+        // Inject some lists.
+        List<String> testList = Lists.newArrayList("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 6; i < 9; ++i) {
+            for (String testValue : testList) {
+                rpush(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some sets.
+        Set<String> testSet = Sets.newHashSet("value_%s1", "value_%s2", "value_%s3");
+        for (int i = 9; i < 12; ++i) {
+            for (String testValue : testSet) {
+                sadd(properties, String.format("test:heterogeneous:%s", i), String.format(testValue, i));
+            }
+        }
+        
+        // Inject some ordered sets.
+        List<String> testOrderedSet = Lists.newArrayList("value_%s3", "value_%s2", "value_%s1");
+        for (int i = 12; i < 15; ++i) {
+            for (String testValue : testOrderedSet) {
+                zadd(properties, String.format("test:heterogeneous:%s", i), i, String.format(testValue, i));
+            }
+        }
+        
+        dummy = this.injector.getInstance(HeterogeneousInMapDefaultValueContainer.class);
+        Map<String, Object> actualObjects = dummy.getInjectedObjects();
+        assertThat(actualObjects.size(), is(15));
+        
+        // Test strings.
+        for (int i = 0; i < 3; ++i) {
+            String actualString = (String)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            assertThat(actualString, is(equalTo(String.format("test_value:%s", i))));
+        }
+        
+        // Test maps.
+        for (int i = 3; i < 6; ++i) {
+            Map<String, String> actualMap = (Map)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            Map<String, String> expectedMap = ImmutableMap.of(
+                String.format("key_%s1", i), String.format("value_%s1", i),
+                String.format("key_%s2", i), String.format("value_%s2", i),
+                String.format("key_%s3", i), String.format("value_%s3", i)
+            );
+            assertThat(actualMap, is(equalTo(expectedMap)));
+        }
+        
+        // Test lists.
+        for (int i = 6; i < 9; ++i) {
+            List<String> actualList = (List)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            List<String> expectedList = Lists.newArrayList(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualList, is(equalTo(expectedList)));
+        }
+        
+        // Test sets.
+        for (int i = 9; i < 12; ++i) {
+            Set<String> actualSet = (Set)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            Set<String> expectedSet = Sets.newHashSet(
+                String.format("value_%s1", i),
+                String.format("value_%s2", i),
+                String.format("value_%s3", i));
+            assertThat(actualSet, is(equalTo(expectedSet)));
+        }
+        
+        // Test ordered sets.
+        for (int i = 12; i < 15; ++i) {
+            Set<String> actualSet = (Set)actualObjects.get(String.format("test:heterogeneous:%s", i));
+            Set<String> expectedSet = Sets.newLinkedHashSet(
+                Lists.newArrayList(
+                    String.format("value_%s3", i),
+                    String.format("value_%s2", i),
+                    String.format("value_%s1", i)
+                )
+            );
+            assertThat(actualSet, is(equalTo(expectedSet)));
+        }
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/BooleanInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/BooleanInjectionTest.java
@@ -1,0 +1,224 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class BooleanInjectionTest extends AbstractModule {
+
+    Properties properties = new Properties();
+    private Injector injector;
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveBooleanContainer {
+
+        @Config(value = "test:boolean", allowNull = false)
+        private boolean injectedBoolean;
+
+        public boolean getInjectedBoolean() {
+            return this.injectedBoolean;
+        }
+    }
+
+    public static class PrimitiveBooleanAllowNullContainer {
+
+        @Config(value = "test:boolean", forceUpdate = true)
+        private boolean injectedBoolean;
+
+        public boolean getInjectedBoolean() {
+            return this.injectedBoolean;
+        }
+    }
+    
+    public static class PrimitiveBooleanDefaultValueContainer {
+        
+        @Config("test:boolean")
+        private boolean injectedBoolean = true;
+        
+        public boolean getInjectedBoolean() {
+            return this.injectedBoolean;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_boolean() {
+        properties.put("test:boolean", "true");
+        PrimitiveBooleanContainer dummy = this.injector.getInstance(
+            PrimitiveBooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(true));
+        properties.put("test:boolean", "F");
+        dummy = this.injector.getInstance(PrimitiveBooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+        properties.put("test:boolean", "Yes");
+        dummy = this.injector.getInstance(PrimitiveBooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(true));
+        properties.put("test:boolean", "0");
+        dummy = this.injector.getInstance(PrimitiveBooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_boolean_to_null() {
+        this.injector.getInstance(PrimitiveBooleanAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_false_into_primitive_boolean() {
+        PrimitiveBooleanContainer dummy = this.injector.getInstance(
+            PrimitiveBooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_boolean() {
+        // Test for case where no value is present in redis database.
+        PrimitiveBooleanDefaultValueContainer dummy = this.injector.getInstance(
+                PrimitiveBooleanDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(true));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:boolean", "false");
+        dummy = this.injector.getInstance(PrimitiveBooleanDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_boolean() {
+        properties.put("test:boolean", "waar");
+        this.injector.getInstance(PrimitiveBooleanContainer.class);
+    }
+
+
+
+    public static class BooleanContainer {
+
+        @Config(value = "test:boolean", allowNull = false)
+        private Boolean injectedBoolean;
+
+        public Boolean getInjectedBoolean() {
+            return this.injectedBoolean;
+        }
+    }
+
+    public static class BooleanAllowNullContainer {
+
+        @Config("test:boolean")
+        private Boolean injectedBoolean;
+
+        public Boolean getInjectedBoolean() {
+            return this.injectedBoolean;
+        }
+    }
+    
+    public static class BooleanDefaultValueContainer {
+        
+        @Config("test:boolean")
+        private Boolean injectedBoolean = Boolean.TRUE;
+        
+        public Boolean getInjectedBoolean() {
+            return this.injectedBoolean;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_boolean() {
+        properties.put("test:boolean", "y");
+        BooleanContainer dummy = this.injector.getInstance(BooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(true));
+        properties.put("test:boolean", "No");
+        dummy = this.injector.getInstance(BooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+        properties.put("test:boolean", "1");
+        dummy = this.injector.getInstance(BooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(true));
+        properties.put("test:boolean", "FALSE");
+        dummy = this.injector.getInstance(BooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_boolean() {
+        BooleanAllowNullContainer dummy = this.injector.getInstance(
+            BooleanAllowNullContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_false_into_boolean() {
+        BooleanContainer dummy = this.injector.getInstance(BooleanContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_boolean() {
+        // Test for case where no value is present in redis database.
+        BooleanDefaultValueContainer dummy = this.injector.getInstance(
+                BooleanDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(true));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:boolean", "false");
+        dummy = this.injector.getInstance(BooleanDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBoolean(), is(false));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_boolean() {
+        properties.put("test:boolean", "vals");
+        this.injector.getInstance(BooleanContainer.class);
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/ByteInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/ByteInjectionTest.java
@@ -1,0 +1,373 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class ByteInjectionTest extends AbstractModule {
+
+    private Injector injector;
+    private Properties properties = new Properties();
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+        properties.clear();
+    }
+
+
+
+    public static class PrimitiveByteArrayContainer {
+
+        @Config(value = "test:bytes", allowNull = false)
+        private byte[] injectedBytes;
+
+        public byte[] getInjectedBytes() {
+            return this.injectedBytes;
+        }
+    }
+
+    public static class PrimitiveByteArrayAllowNullContainer {
+
+        @Config("test:bytes")
+        private byte[] injectedBytes;
+
+        public byte[] getInjectedBytes() {
+            return this.injectedBytes;
+        }
+    }
+    
+    public static class PrimitiveByteArrayDefaultValueContainer {
+
+        @Config("test:bytes")
+        private byte[] injectedBytes = {(byte)1, (byte)2, (byte)3};
+
+        public byte[] getInjectedBytes() {
+            return this.injectedBytes;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_primitive_byte_array() {
+        properties.put("test:bytes", "test_value");
+        PrimitiveByteArrayContainer dummy = this.injector.getInstance(
+            PrimitiveByteArrayContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(equalTo("test_value".getBytes())));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_primitive_byte_array() {
+        PrimitiveByteArrayAllowNullContainer dummy = this.injector.getInstance(
+            PrimitiveByteArrayAllowNullContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_empty_array_into_primitive_byte_array() {
+        PrimitiveByteArrayContainer dummy = this.injector.getInstance(
+            PrimitiveByteArrayContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(equalTo(new byte[]{})));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_byte_array() {
+        // Test for case where no value is present in redis database.
+        PrimitiveByteArrayDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveByteArrayDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(equalTo(new byte[]{(byte)1, (byte)2, (byte)3})));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:bytes", "test_value");
+        dummy = this.injector.getInstance(PrimitiveByteArrayDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(equalTo("test_value".getBytes())));
+    }
+
+
+
+    public static class ByteArrayContainer {
+
+        @Config(value = "test:bytes", allowNull = false)
+        private Byte[] injectedBytes;
+
+        public Byte[] getInjectedBytes() {
+            return this.injectedBytes;
+        }
+    }
+
+    public static class ByteArrayAllowNullContainer {
+
+        @Config("test:bytes")
+        private Byte[] injectedBytes;
+
+        public Byte[] getInjectedBytes() {
+            return this.injectedBytes;
+        }
+    }
+    
+    public static class ByteArrayDefaultValueContainer {
+
+        @Config("test:bytes")
+        private Byte[] injectedBytes = {(byte)1, (byte)2, (byte)3};
+
+        public Byte[] getInjectedBytes() {
+            return this.injectedBytes;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_byte_array() {
+        properties.put("test:bytes", "test_value");
+        ByteArrayContainer dummy = this.injector.getInstance(ByteArrayContainer.class);
+        assertThat(ArrayUtils.toPrimitive(dummy.getInjectedBytes()), is(equalTo("test_value".getBytes())));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_byte_array() {
+        ByteArrayAllowNullContainer dummy = this.injector.getInstance(
+            ByteArrayAllowNullContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_empty_array_into_byte_array() {
+        ByteArrayContainer dummy = this.injector.getInstance(
+            ByteArrayContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(equalTo(new Byte[]{})));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_byte_array() {
+        // Test for case where no value is present in redis database.
+        ByteArrayDefaultValueContainer dummy = this.injector.getInstance(
+            ByteArrayDefaultValueContainer.class);
+        assertThat(dummy.getInjectedBytes(), is(equalTo(new Byte[]{(byte)1, (byte)2, (byte)3})));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:bytes", "test_value");
+        dummy = this.injector.getInstance(ByteArrayDefaultValueContainer.class);
+        assertThat(ArrayUtils.toPrimitive(dummy.getInjectedBytes()), is(equalTo("test_value".getBytes())));
+    }
+
+
+
+    public static class PrimitiveByteContainer {
+
+        @Config(value = "test:byte", allowNull = false)
+        private byte injectedByte;
+
+        public byte getInjectedByte() {
+            return this.injectedByte;
+        }
+    }
+
+    public static class PrimitiveByteAllowNullContainer {
+
+        @Config(value = "test:byte", forceUpdate = true)
+        private byte injectedByte;
+
+        public byte getInjectedByte() {
+            return this.injectedByte;
+        }
+    }
+    
+    public static class PrimitiveByteDefaultValueContainer {
+
+        @Config("test:byte")
+        private byte injectedByte = (byte)12;
+
+        public byte getInjectedByte() {
+            return this.injectedByte;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_byte() {
+        properties.put("test:byte", "12");
+        PrimitiveByteContainer dummy = this.injector.getInstance(PrimitiveByteContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)12));
+        properties.put("test:byte", "-13");
+        dummy = this.injector.getInstance(PrimitiveByteContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)-13));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_byte_to_null() {
+        this.injector.getInstance(PrimitiveByteAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_primitive_byte() {
+        PrimitiveByteContainer dummy = this.injector.getInstance(
+            PrimitiveByteContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_byte() {
+        // Test for case where no value is present in redis database.
+        PrimitiveByteDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveByteDefaultValueContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)12));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:byte", "-13");
+        dummy = this.injector.getInstance(PrimitiveByteDefaultValueContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)-13));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_byte() {
+        properties.put("test:byte", "invalid");
+        this.injector.getInstance(PrimitiveByteContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_primitive_byte() {
+        properties.put("test:byte", "-129");
+        this.injector.getInstance(PrimitiveByteContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_primitive_byte() {
+        properties.put("test:byte", "128");
+        this.injector.getInstance(PrimitiveByteContainer.class);
+    }
+
+
+
+    public static class ByteContainer {
+
+        @Config(value = "test:byte", allowNull = false)
+        private Byte injectedByte;
+
+        public Byte getInjectedByte() {
+            return this.injectedByte;
+        }
+    }
+
+    public static class ByteAllowNullContainer {
+
+        @Config("test:byte")
+        private Byte injectedByte;
+
+        public Byte getInjectedByte() {
+            return this.injectedByte;
+        }
+    }
+    
+    public static class ByteDefaultValueContainer {
+
+        @Config("test:byte")
+        private Byte injectedByte = (byte)12;
+
+        public Byte getInjectedByte() {
+            return this.injectedByte;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_byte() {
+        properties.put("test:byte", "12");
+        ByteContainer dummy = this.injector.getInstance(ByteContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)12));
+        properties.put("test:byte", "-13");
+        dummy = this.injector.getInstance(ByteContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)-13));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_byte() {
+        ByteAllowNullContainer dummy = this.injector.getInstance(
+            ByteAllowNullContainer.class);
+        assertThat(dummy.getInjectedByte(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_byte() {
+        ByteContainer dummy = this.injector.getInstance(ByteContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_byte() {
+        // Test for case where no value is present in redis database.
+        ByteDefaultValueContainer dummy = this.injector.getInstance(
+            ByteDefaultValueContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)12));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:byte", "-13");
+        dummy = this.injector.getInstance(ByteDefaultValueContainer.class);
+        assertThat(dummy.getInjectedByte(), is((byte)-13));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_byte() {
+        properties.put("test:byte", "invalid");
+        this.injector.getInstance(ByteContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_byte() {
+        properties.put("test:byte", "-129");
+        this.injector.getInstance(ByteContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_byte() {
+        properties.put("test:byte", "128");
+        this.injector.getInstance(ByteContainer.class);
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/CharInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/CharInjectionTest.java
@@ -1,0 +1,340 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class CharInjectionTest extends AbstractModule {
+
+    private Injector injector;
+    private Properties properties = new Properties();
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveCharArrayContainer {
+
+        @Config(value = "test:chars", allowNull = false)
+        private char[] injectedChars;
+
+        public char[] getInjectedChars() {
+            return this.injectedChars;
+        }
+    }
+
+    public static class PrimitiveCharArrayAllowNullContainer {
+
+        @Config("test:chars")
+        private char[] injectedChars;
+
+        public char[] getInjectedChars() {
+            return this.injectedChars;
+        }
+    }
+    
+    public static class PrimitiveCharArrayDefaultValueContainer {
+
+        @Config("test:chars")
+        private char[] injectedChars = {'t', 'e', 's', 't'};
+
+        public char[] getInjectedChars() {
+            return this.injectedChars;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_primitive_char_array() {
+        properties.put("test:chars", "test_value");
+        PrimitiveCharArrayContainer dummy = this.injector.getInstance(
+            PrimitiveCharArrayContainer.class);
+        assertThat(dummy.getInjectedChars(), is(equalTo("test_value".toCharArray())));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_primitive_char_array() {
+        PrimitiveCharArrayAllowNullContainer dummy = this.injector.getInstance(
+            PrimitiveCharArrayAllowNullContainer.class);
+        assertThat(dummy.getInjectedChars(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_empty_array_into_primitive_char_array() {
+        PrimitiveCharArrayContainer dummy = this.injector.getInstance(
+            PrimitiveCharArrayContainer.class);
+        assertThat(dummy.getInjectedChars(), is(equalTo(new char[]{})));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_char_array() {
+        // Test for case where no value is present in redis database.
+        PrimitiveCharArrayDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveCharArrayDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChars(), is(equalTo(new char[]{'t', 'e', 's', 't'})));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:chars", "test_value");
+        dummy = this.injector.getInstance(PrimitiveCharArrayDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChars(), is(equalTo("test_value".toCharArray())));
+    }
+
+
+
+    public static class CharArrayContainer {
+
+        @Config(value = "test:chars", allowNull = false)
+        private Character[] injectedChars;
+
+        public Character[] getInjectedChars() {
+            return this.injectedChars;
+        }
+    }
+
+    public static class CharArrayAllowNullContainer {
+
+        @Config("test:chars")
+        private Character[] injectedChars;
+
+        public Character[] getInjectedChars() {
+            return this.injectedChars;
+        }
+    }
+    
+    public static class CharArrayDefaultValueContainer {
+
+        @Config("test:chars")
+        private Character[] injectedChars = {'t', 'e', 's', 't'};
+
+        public Character[] getInjectedChars() {
+            return this.injectedChars;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_char_array() {
+        properties.put("test:chars", "test_value");
+        CharArrayContainer dummy = this.injector.getInstance(CharArrayContainer.class);
+        assertThat(ArrayUtils.toPrimitive(dummy.getInjectedChars()), is(equalTo("test_value".toCharArray())));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_char_array() {
+        CharArrayAllowNullContainer dummy = this.injector.getInstance(
+            CharArrayAllowNullContainer.class);
+        assertThat(dummy.getInjectedChars(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_empty_array_into_char_array() {
+        CharArrayContainer dummy = this.injector.getInstance(CharArrayContainer.class);
+        assertThat(dummy.getInjectedChars(), is(equalTo(new Character[]{})));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_char_array() {
+        // Test for case where no value is present in redis database.
+        CharArrayDefaultValueContainer dummy = this.injector.getInstance(
+            CharArrayDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChars(), is(equalTo(new Character[]{'t', 'e', 's', 't'})));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:chars", "test_value");
+        dummy = this.injector.getInstance(CharArrayDefaultValueContainer.class);
+        assertThat(ArrayUtils.toPrimitive(dummy.getInjectedChars()), is(equalTo("test_value".toCharArray())));
+    }
+
+
+
+    public static class PrimitiveCharContainer {
+
+        @Config(value = "test:char", allowNull = false)
+        private char injectedChar;
+
+        public char getInjectedChar() {
+            return this.injectedChar;
+        }
+    }
+
+    public static class PrimitiveCharAllowNullContainer {
+
+        @Config(value = "test:char", forceUpdate = true)
+        private char injectedChar;
+
+        public char getInjectedChar() {
+            return this.injectedChar;
+        }
+    }
+    
+    public static class PrimitiveCharDefaultValueContainer {
+
+        @Config("test:char")
+        private char injectedChar = 't';
+
+        public char getInjectedChar() {
+            return this.injectedChar;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_char() {
+        properties.put("test:char", "A");
+        PrimitiveCharContainer dummy = this.injector.getInstance(PrimitiveCharContainer.class);
+        assertThat(dummy.getInjectedChar(), is('A'));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_char_to_null() {
+        this.injector.getInstance(PrimitiveCharAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_character_into_primitive_char() {
+        PrimitiveCharContainer dummy = this.injector.getInstance(PrimitiveCharContainer.class);
+        assertThat(dummy.getInjectedChar(), is('\0'));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_char() {
+        // Test for case where no value is present in redis database.
+        PrimitiveCharDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveCharDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChar(), is('t'));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:char", "A");
+        dummy = this.injector.getInstance(PrimitiveCharDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChar(), is('A'));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_char() {
+        properties.put("test:char", "invalid");
+        this.injector.getInstance(PrimitiveCharContainer.class);
+    }
+
+
+
+    public static class CharContainer {
+
+        @Config(value = "test:char", allowNull = false)
+        private Character injectedChar;
+
+        public Character getInjectedChar() {
+            return this.injectedChar;
+        }
+    }
+
+    public static class CharAllowNullContainer {
+
+        @Config("test:char")
+        private Character injectedChar;
+
+        public Character getInjectedChar() {
+            return this.injectedChar;
+        }
+    }
+    
+    public static class CharDefaultValueContainer {
+
+        @Config("test:char")
+        private Character injectedChar = 't';
+
+        public Character getInjectedChar() {
+            return this.injectedChar;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_char() {
+        properties.put("test:char", "A");
+        CharContainer dummy = this.injector.getInstance(CharContainer.class);
+        assertThat(dummy.getInjectedChar(), is('A'));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_char() {
+        CharAllowNullContainer dummy = this.injector.getInstance(
+            CharAllowNullContainer.class);
+        assertThat(dummy.getInjectedChar(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_char() {
+        CharContainer dummy = this.injector.getInstance(CharContainer.class);
+        assertThat(dummy.getInjectedChar(), is('\0'));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_char() {
+        // Test for case where no value is present in redis database.
+        CharDefaultValueContainer dummy = this.injector.getInstance(
+            CharDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChar(), is('t'));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:char", "A");
+        dummy = this.injector.getInstance(CharDefaultValueContainer.class);
+        assertThat(dummy.getInjectedChar(), is('A'));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_char() {
+        properties.put("test:char", "invalid");
+        this.injector.getInstance(CharContainer.class);
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/DoubleInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/DoubleInjectionTest.java
@@ -1,0 +1,248 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class DoubleInjectionTest extends AbstractModule {
+
+    Properties properties = new Properties();
+
+    private Injector injector;
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveDoubleContainer {
+
+        @Config(value = "test:double", allowNull = false)
+        private double injectedDouble;
+
+        public double getInjectedDouble() {
+            return this.injectedDouble;
+        }
+    }
+
+    public static class PrimitiveDoubleAllowNullContainer {
+
+        @Config(value = "test:double", forceUpdate = true)
+        private double injectedDouble;
+
+        public double getInjectedDouble() {
+            return this.injectedDouble;
+        }
+    }
+    
+    public static class PrimitiveDoubleDefaultValueContainer {
+
+        @Config("test:double")
+        private double injectedDouble = 123.4;
+
+        public double getInjectedDouble() {
+            return this.injectedDouble;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_double() {
+        properties.put("test:double", "123.456");
+        PrimitiveDoubleContainer dummy = this.injector.getInstance(PrimitiveDoubleContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(123.456));
+        properties.put("test:double", ".123");
+        dummy = this.injector.getInstance(PrimitiveDoubleContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(0.123));
+        properties.put("test:double", "NaN");
+        dummy = this.injector.getInstance(PrimitiveDoubleContainer.class);
+        assertThat(Double.isNaN(dummy.getInjectedDouble()), is(true));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_double_to_null() {
+        this.injector.getInstance(PrimitiveDoubleAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_primitive_double() {
+        PrimitiveDoubleContainer dummy = this.injector.getInstance(
+            PrimitiveDoubleContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(0.0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_double() {
+        // Test for case where no value is present in redis database.
+        PrimitiveDoubleDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveDoubleDefaultValueContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(123.4));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:double", "4.56");
+        dummy = this.injector.getInstance(PrimitiveDoubleDefaultValueContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(4.56));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_double() {
+        properties.put("test:double", "invalid");
+        this.injector.getInstance(PrimitiveDoubleContainer.class);
+    }
+
+    @Test
+    public void test_that_too_small_value_overflows_to_infinity_when_converting_to_primitive_double() {
+        properties.put("test:double", "-1.7976931348623159e+308");
+        PrimitiveDoubleContainer dummy = this.injector.getInstance(
+            PrimitiveDoubleContainer.class);
+        assertThat(Double.isInfinite(dummy.getInjectedDouble()), is(true));
+    }
+
+    @Test
+    public void test_that_too_large_value_overflows_to_infinity_when_converting_to_primitive_double() {
+        properties.put("test:double", "1.7976931348623159e+308");
+        PrimitiveDoubleContainer dummy = this.injector.getInstance(
+            PrimitiveDoubleContainer.class);
+        assertThat(Double.isInfinite(dummy.getInjectedDouble()), is(true));
+    }
+
+
+
+    public static class DoubleContainer {
+
+        @Config(value = "test:double", allowNull = false)
+        private Double injectedDouble;
+
+        public Double getInjectedDouble() {
+            return this.injectedDouble;
+        }
+    }
+
+    public static class DoubleAllowNullContainer {
+
+        @Config("test:double")
+        private Double injectedDouble;
+
+        public Double getInjectedDouble() {
+            return this.injectedDouble;
+        }
+    }
+    
+    public static class DoubleDefaultValueContainer {
+
+        @Config("test:double")
+        private Double injectedDouble = 123.4;
+
+        public Double getInjectedDouble() {
+            return this.injectedDouble;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_double() {
+        properties.put("test:double", "123.456");
+        DoubleContainer dummy = this.injector.getInstance(DoubleContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(123.456));
+        properties.put("test:double", ".123");
+        dummy = this.injector.getInstance(DoubleContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(0.123));
+        properties.put("test:double", "NaN");
+        dummy = this.injector.getInstance(DoubleContainer.class);
+        assertThat(dummy.getInjectedDouble().isNaN(), is(true));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_double() {
+        DoubleAllowNullContainer dummy = this.injector.getInstance(
+            DoubleAllowNullContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_double() {
+        DoubleContainer dummy = this.injector.getInstance(DoubleContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(0.0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_double() {
+        // Test for case where no value is present in redis database.
+        DoubleDefaultValueContainer dummy = this.injector.getInstance(
+            DoubleDefaultValueContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(123.4));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:double", "4.56");
+        dummy = this.injector.getInstance(DoubleDefaultValueContainer.class);
+        assertThat(dummy.getInjectedDouble(), is(4.56));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_double() {
+        properties.put("test:double", "invalid");
+        this.injector.getInstance(DoubleContainer.class);
+    }
+
+    @Test
+    public void test_that_too_small_value_overflows_to_infinity_when_converting_to_double() {
+        properties.put("test:double", "-1.7976931348623159e+308");
+        DoubleContainer dummy = this.injector.getInstance(DoubleContainer.class);
+        assertThat(dummy.getInjectedDouble().isInfinite(), is(true));
+    }
+
+    @Test
+    public void test_that_too_large_value_overflows_to_infinity_when_converting_to_double() {
+        properties.put("test:double", "1.7976931348623159e+308");
+        DoubleContainer dummy = this.injector.getInstance(DoubleContainer.class);
+        assertThat(dummy.getInjectedDouble().isInfinite(), is(true));
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/FloatInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/FloatInjectionTest.java
@@ -1,0 +1,253 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class FloatInjectionTest extends AbstractModule {
+
+    private Injector injector;
+    Properties properties = new Properties();
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveFloatContainer {
+
+        @Config(value = "test:float", allowNull = false)
+        private float injectedFloat;
+
+        public float getInjectedFloat() {
+            return this.injectedFloat;
+        }
+    }
+
+    public static class PrimitiveFloatAllowNullContainer {
+
+        @Config(value = "test:float", forceUpdate = true)
+        private float injectedFloat;
+
+        public float getInjectedFloat() {
+            return this.injectedFloat;
+        }
+    }
+    
+    public static class PrimitiveFloatDefaultValueContainer{
+
+        @Config("test:float")
+        private float injectedFloat = 123.4f;
+
+        public float getInjectedFloat() {
+            return this.injectedFloat;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_float() {
+        properties.put("test:float", "123.456");
+        PrimitiveFloatContainer dummy = this.injector.getInstance(PrimitiveFloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(123.456f));
+        properties.put("test:float", ".123");
+        dummy = this.injector.getInstance(PrimitiveFloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(0.123f));
+        properties.put("test:float", "1.23f");
+        dummy = this.injector.getInstance(PrimitiveFloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(1.23f));
+        properties.put("test:float", "NaN");
+        dummy = this.injector.getInstance(PrimitiveFloatContainer.class);
+        assertThat(Float.isNaN(dummy.getInjectedFloat()), is(true));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_float_to_null() {
+        this.injector.getInstance(PrimitiveFloatAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_primitive_float() {
+        PrimitiveFloatContainer dummy = this.injector.getInstance(
+            PrimitiveFloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(0.0f));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_float() {
+        // Test for case where no value is present in redis database.
+        PrimitiveFloatDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveFloatDefaultValueContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(123.4f));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:float", "4.56");
+        dummy = this.injector.getInstance(PrimitiveFloatDefaultValueContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(4.56f));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_float() {
+        properties.put("test:float", "invalid");
+        this.injector.getInstance(PrimitiveFloatContainer.class);
+    }
+
+    @Test
+    public void test_that_too_small_value_overflows_to_infinity_when_converting_to_primitive_float() {
+        properties.put("test:float", "-3.4028236e+38f");
+        PrimitiveFloatContainer dummy = this.injector.getInstance(
+            PrimitiveFloatContainer.class);
+        assertThat(Float.isInfinite(dummy.getInjectedFloat()), is(true));
+    }
+
+    @Test
+    public void test_that_too_large_value_overflows_to_infinity_when_converting_to_primitive_float() {
+        properties.put("test:float", "3.4028236e+38f");
+        PrimitiveFloatContainer dummy = this.injector.getInstance(
+            PrimitiveFloatContainer.class);
+        assertThat(Float.isInfinite(dummy.getInjectedFloat()), is(true));
+    }
+
+
+
+    public static class FloatContainer {
+
+        @Config(value = "test:float", allowNull = false)
+        private Float injectedFloat;
+
+        public Float getInjectedFloat() {
+            return this.injectedFloat;
+        }
+    }
+
+    public static class FloatAllowNullContainer {
+
+        @Config("test:float")
+        private Float injectedFloat;
+
+        public Float getInjectedFloat() {
+            return this.injectedFloat;
+        }
+    }
+    
+    public static class FloatDefaultValueContainer {
+
+        @Config("test:float")
+        private Float injectedFloat = 123.4f;
+
+        public Float getInjectedFloat() {
+            return this.injectedFloat;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_float() {
+        properties.put("test:float", "123.456");
+        FloatContainer dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(123.456f));
+        properties.put("test:float", ".123");
+        dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(0.123f));
+        properties.put("test:float", "1.23f");
+        dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(1.23f));
+        properties.put("test:float", "NaN");
+        dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat().isNaN(), is(true));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_float() {
+        FloatAllowNullContainer dummy = this.injector.getInstance(
+            FloatAllowNullContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_float() {
+        FloatContainer dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(0.0f));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_float() {
+        // Test for case where no value is present in redis database.
+        FloatDefaultValueContainer dummy = this.injector.getInstance(
+            FloatDefaultValueContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(123.4f));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:float", "4.56");
+        dummy = this.injector.getInstance(FloatDefaultValueContainer.class);
+        assertThat(dummy.getInjectedFloat(), is(4.56f));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_float() {
+        properties.put("test:float", "invalid");
+        this.injector.getInstance(FloatContainer.class);
+    }
+
+    @Test
+    public void test_that_too_small_value_overflows_to_infinity_when_converting_to_float() {
+        properties.put("test:float", "-3.4028236e+38f");
+        FloatContainer dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat().isInfinite(), is(true));
+    }
+
+    @Test
+    public void test_that_too_large_value_overflows_to_infinity_when_converting_to_float() {
+        properties.put("test:float", "3.4028236e+38f");
+        FloatContainer dummy = this.injector.getInstance(FloatContainer.class);
+        assertThat(dummy.getInjectedFloat().isInfinite(), is(true));
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/IntegerInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/IntegerInjectionTest.java
@@ -1,0 +1,235 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class IntegerInjectionTest extends AbstractModule {
+
+    Properties properties = new Properties();
+    private Injector injector;
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveIntegerContainer {
+
+        @Config(value = "test:integer", allowNull = false)
+        private int injectedInteger;
+
+        public int getInjectedInteger() {
+            return this.injectedInteger;
+        }
+    }
+
+    public static class PrimitiveIntegerAllowNullContainer {
+
+        @Config(value = "test:integer", forceUpdate = true)
+        private int injectedInteger;
+
+        public int getInjectedInteger() {
+            return this.injectedInteger;
+        }
+    }
+    
+    public static class PrimitiveIntegerDefaultValueContainer {
+
+        @Config("test:integer")
+        private int injectedInteger = 123;
+
+        public int getInjectedInteger() {
+            return this.injectedInteger;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_integer() {
+        properties.put("test:integer", "123");
+        PrimitiveIntegerContainer dummy = this.injector.getInstance(PrimitiveIntegerContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(123));
+        properties.put("test:integer", "-123");
+        dummy = this.injector.getInstance(PrimitiveIntegerContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(-123));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_integer_to_null() {
+        this.injector.getInstance(PrimitiveIntegerAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_primitive_integer() {
+        PrimitiveIntegerContainer dummy = this.injector.getInstance(
+            PrimitiveIntegerContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_integer() {
+        // Test for case where no value is present in redis database.
+        PrimitiveIntegerDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveIntegerDefaultValueContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(123));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:integer", "456");
+        dummy = this.injector.getInstance(PrimitiveIntegerDefaultValueContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(456));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_integer() {
+        properties.put("test:integer", "invalid");
+        this.injector.getInstance(PrimitiveIntegerContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_primitive_integer() {
+        properties.put("test:integer", "-2147483649");
+        this.injector.getInstance(PrimitiveIntegerContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_primitive_integer() {
+        properties.put("test:integer", "2147483648");
+        this.injector.getInstance(PrimitiveIntegerContainer.class);
+    }
+
+
+
+    public static class IntegerContainer {
+
+        @Config(value = "test:integer", allowNull = false)
+        private Integer injectedInteger;
+
+        public Integer getInjectedInteger() {
+            return this.injectedInteger;
+        }
+    }
+
+    public static class IntegerAllowNullContainer {
+
+        @Config("test:integer")
+        private Integer injectedInteger;
+
+        public Integer getInjectedInteger() {
+            return this.injectedInteger;
+        }
+    }
+    
+    public static class IntegerDefaultValueContainer {
+
+        @Config("test:integer")
+        private Integer injectedInteger = 123;
+
+        public Integer getInjectedInteger() {
+            return this.injectedInteger;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_integer() {
+        properties.put("test:integer", "123");
+        IntegerContainer dummy = this.injector.getInstance(IntegerContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(123));
+        properties.put("test:integer", "-123");
+        dummy = this.injector.getInstance(IntegerContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(-123));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_integer() {
+        IntegerAllowNullContainer dummy = this.injector.getInstance(
+            IntegerAllowNullContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_integer() {
+        IntegerContainer dummy = this.injector.getInstance(IntegerContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_integer() {
+        // Test for case where no value is present in redis database.
+        IntegerDefaultValueContainer dummy = this.injector.getInstance(
+            IntegerDefaultValueContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(123));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:integer", "456");
+        dummy = this.injector.getInstance(IntegerDefaultValueContainer.class);
+        assertThat(dummy.getInjectedInteger(), is(456));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_integer() {
+        properties.put("test:integer", "invalid");
+        this.injector.getInstance(IntegerContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_integer() {
+        properties.put("test:integer", "-2147483649");
+        this.injector.getInstance(IntegerContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_integer() {
+        properties.put("test:integer", "2147483648");
+        this.injector.getInstance(IntegerContainer.class);
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/ListInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/ListInjectionTest.java
@@ -1,0 +1,229 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Joiner;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class ListInjectionTest extends AbstractModule {
+    
+    private Injector injector;
+    Properties properties = new Properties();
+    
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+        this.properties.clear();
+    }
+
+    @After
+    public void teardown() {
+    }
+    
+    
+    
+    public static class ListContainer {
+
+        @Config(value = "test:list", allowNull = false)
+        private List<String> injectedList;
+
+        public List<String> getInjectedList() {
+            return this.injectedList;
+        }
+    }
+    
+    public static class ListAllowNullContainer {
+
+        @Config("test:list")
+        private List<String> injectedList;
+
+        public List<String> getInjectedList() {
+            return this.injectedList;
+        }
+    }
+    
+    public static class ListDefaultValueContainer {
+        
+        @Config("test:list")
+        private List<String> injectedList = ImmutableList.of(
+            "def_value_01", "def_value_02", "def_value_03"
+        );
+        
+        public List<String> getInjectedList() {
+            return this.injectedList;
+        }
+    }
+    
+    @Test
+    public void test_that_list_is_injected_into_list() {
+        List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
+        properties.put("test:list",Joiner.on(",").join(expectedList));
+        ListContainer dummy = this.injector.getInstance(ListContainer.class);
+        assertThat(dummy.getInjectedList(), is(equalTo(expectedList)));
+    }
+    
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_list() {
+        ListAllowNullContainer dummy = this.injector.getInstance(
+            ListAllowNullContainer.class);
+        assertThat(dummy.getInjectedList(), is(nullValue()));
+    }
+    
+    @Test
+    public void test_that_missing_value_is_injected_as_empty_list_into_list() {
+        ListContainer dummy = this.injector.getInstance(ListContainer.class);
+        assertThat(dummy.getInjectedList(), is(equalTo(Collections.EMPTY_LIST)));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_list() {
+        // Test for case where no value is present in redis database.
+        ListDefaultValueContainer dummy = this.injector.getInstance(
+            ListDefaultValueContainer.class);
+        List<String> defaultList = ImmutableList.of("def_value_01", "def_value_02", "def_value_03");
+        assertThat(dummy.getInjectedList(), is(equalTo(defaultList)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
+        properties.put("test:list",Joiner.on(",").join(expectedList));
+        dummy = this.injector.getInstance(ListDefaultValueContainer.class);
+        assertThat(dummy.getInjectedList(), is(equalTo(expectedList)));
+    }
+    
+    
+    
+    public static class ListAsSetContainer {
+        
+        @Config("test:list")
+        private Set<String> injectedSet;
+        
+        public Set<String> getInjectedSet() {
+            return this.injectedSet;
+        }
+    }
+    
+    @Test
+    public void test_that_list_is_injected_into_set() {
+        List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
+        properties.put("test:list",Joiner.on(",").join(expectedList));
+        ListAsSetContainer dummy = this.injector.getInstance(ListAsSetContainer.class);
+        Set<String> actualSet = dummy.getInjectedSet();
+        assertThat(actualSet, is(equalTo((Set)Sets.newHashSet(expectedList))));
+    }
+    
+    
+    
+    public static class ListInMapContainer {
+
+        @Config("test:list")
+        private Map<String, List<String>> injectedList;
+
+        public Map<String, List<String>> getInjectedList() {
+            return this.injectedList;
+        }
+    }
+    
+    @Test
+    public void test_that_list_is_injected_into_map_of_list() {
+        List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
+        properties.put("test:list",Joiner.on(",").join(expectedList));
+        ListInMapContainer dummy = this.injector.getInstance(ListInMapContainer.class);
+        Map<String, List<String>> actualMapList = dummy.getInjectedList();
+        assertThat(actualMapList.size(), is(1));
+        assertThat(actualMapList.get("test:list"), is(equalTo(expectedList)));
+    }
+    
+    
+    
+    public static class ListInListContainer {
+
+        @Config("test:list")
+        private List<List<String>> injectedList;
+
+        public List<List<String>> getInjectedList() {
+            return this.injectedList;
+        }
+    }
+    
+    @Test
+    public void test_that_list_is_injected_into_list_of_list() {
+        List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
+        properties.put("test:list",Joiner.on(",").join(expectedList));
+        ListInListContainer dummy = this.injector.getInstance(ListInListContainer.class);
+        List<List<String>> actualListList = dummy.getInjectedList();
+        assertThat(actualListList.size(), is(1));
+        assertThat(actualListList.get(0), is(equalTo(expectedList)));
+    }
+    
+    
+    
+    public static class ListInSetContainer {
+        
+        @Config("test:list")
+        private Set<List<String>> injectedList;
+        
+        public Set<List<String>> getInjectedList() {
+            return this.injectedList;
+        }
+    }
+    
+    @Test
+    public void test_that_list_is_injected_into_set_of_list() {
+        List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
+        properties.put("test:list",Joiner.on(",").join(expectedList));
+        ListInSetContainer dummy = this.injector.getInstance(ListInSetContainer.class);
+        Set<List<String>> actualSetList = dummy.getInjectedList();
+        assertThat(actualSetList.size(), is(1));
+        assertThat(Iterables.getOnlyElement(actualSetList), is(equalTo(expectedList)));
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/ListInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/ListInjectionTest.java
@@ -42,7 +42,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
-import com.google.common.base.Joiner;
 import java.util.Properties;
 
 /**
@@ -106,7 +105,7 @@ public class ListInjectionTest extends AbstractModule {
     @Test
     public void test_that_list_is_injected_into_list() {
         List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
-        properties.put("test:list",Joiner.on(",").join(expectedList));
+        properties.put("test:list",expectedList);
         ListContainer dummy = this.injector.getInstance(ListContainer.class);
         assertThat(dummy.getInjectedList(), is(equalTo(expectedList)));
     }
@@ -135,7 +134,7 @@ public class ListInjectionTest extends AbstractModule {
         // Test for case where value is present in redis database.
         // Default value should be overwritten.
         List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
-        properties.put("test:list",Joiner.on(",").join(expectedList));
+        properties.put("test:list",expectedList);
         dummy = this.injector.getInstance(ListDefaultValueContainer.class);
         assertThat(dummy.getInjectedList(), is(equalTo(expectedList)));
     }
@@ -155,7 +154,7 @@ public class ListInjectionTest extends AbstractModule {
     @Test
     public void test_that_list_is_injected_into_set() {
         List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
-        properties.put("test:list",Joiner.on(",").join(expectedList));
+        properties.put("test:list",expectedList);
         ListAsSetContainer dummy = this.injector.getInstance(ListAsSetContainer.class);
         Set<String> actualSet = dummy.getInjectedSet();
         assertThat(actualSet, is(equalTo((Set)Sets.newHashSet(expectedList))));
@@ -176,7 +175,7 @@ public class ListInjectionTest extends AbstractModule {
     @Test
     public void test_that_list_is_injected_into_map_of_list() {
         List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
-        properties.put("test:list",Joiner.on(",").join(expectedList));
+        properties.put("test:list",expectedList);
         ListInMapContainer dummy = this.injector.getInstance(ListInMapContainer.class);
         Map<String, List<String>> actualMapList = dummy.getInjectedList();
         assertThat(actualMapList.size(), is(1));
@@ -198,7 +197,7 @@ public class ListInjectionTest extends AbstractModule {
     @Test
     public void test_that_list_is_injected_into_list_of_list() {
         List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
-        properties.put("test:list",Joiner.on(",").join(expectedList));
+        properties.put("test:list",expectedList);
         ListInListContainer dummy = this.injector.getInstance(ListInListContainer.class);
         List<List<String>> actualListList = dummy.getInjectedList();
         assertThat(actualListList.size(), is(1));
@@ -220,7 +219,7 @@ public class ListInjectionTest extends AbstractModule {
     @Test
     public void test_that_list_is_injected_into_set_of_list() {
         List<String> expectedList = Lists.newArrayList("value_01", "value_02", "value_03");
-        properties.put("test:list",Joiner.on(",").join(expectedList));
+        properties.put("test:list",expectedList);
         ListInSetContainer dummy = this.injector.getInstance(ListInSetContainer.class);
         Set<List<String>> actualSetList = dummy.getInjectedList();
         assertThat(actualSetList.size(), is(1));

--- a/src/test/java/com/github/strawberry/guice/config/LongInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/LongInjectionTest.java
@@ -1,0 +1,235 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class LongInjectionTest extends AbstractModule {
+
+    Properties properties = new Properties();
+    private Injector injector;
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveLongContainer {
+
+        @Config(value = "test:long", allowNull = false)
+        private long injectedLong;
+
+        public long getInjectedLong() {
+            return this.injectedLong;
+        }
+    }
+
+    public static class PrimitiveLongAllowNullContainer {
+
+        @Config(value = "test:long", forceUpdate = true)
+        private long injectedLong;
+
+        public long getInjectedLong() {
+            return this.injectedLong;
+        }
+    }
+    
+    public static class PrimitiveLongDefaultValueContainer {
+
+        @Config("test:long")
+        private long injectedLong = 123L;
+
+        public long getInjectedLong() {
+            return this.injectedLong;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_long() {
+        properties.put("test:long", "123");
+        PrimitiveLongContainer dummy = this.injector.getInstance(PrimitiveLongContainer.class);
+        assertThat(dummy.getInjectedLong(), is(123L));
+        properties.put("test:long", "-123");
+        dummy = this.injector.getInstance(PrimitiveLongContainer.class);
+        assertThat(dummy.getInjectedLong(), is(-123L));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_long_to_null() {
+        this.injector.getInstance(PrimitiveLongAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_primitive_long() {
+        PrimitiveLongContainer dummy = this.injector.getInstance(
+            PrimitiveLongContainer.class);
+        assertThat(dummy.getInjectedLong(), is(0L));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_long() {
+        // Test for case where no value is present in redis database.
+        PrimitiveLongDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveLongDefaultValueContainer.class);
+        assertThat(dummy.getInjectedLong(), is(123L));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:long", "456");
+        dummy = this.injector.getInstance(PrimitiveLongDefaultValueContainer.class);
+        assertThat(dummy.getInjectedLong(), is(456L));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_long() {
+        properties.put("test:long", "invalid");
+        this.injector.getInstance(PrimitiveLongContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_primitive_long() {
+        properties.put("test:long", "-9223372036854775809");
+        this.injector.getInstance(PrimitiveLongContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_primitive_long() {
+        properties.put("test:long", "9223372036854775808");
+        this.injector.getInstance(PrimitiveLongContainer.class);
+    }
+
+
+
+    public static class LongContainer {
+
+        @Config(value = "test:long", allowNull = false)
+        private Long injectedLong;
+
+        public Long getInjectedLong() {
+            return this.injectedLong;
+        }
+    }
+
+    public static class LongAllowNullContainer {
+
+        @Config("test:long")
+        private Long injectedLong;
+
+        public Long getInjectedLong() {
+            return this.injectedLong;
+        }
+    }
+    
+    public static class LongDefaultValueContainer {
+
+        @Config("test:long")
+        private Long injectedLong = 123L;
+
+        public Long getInjectedLong() {
+            return this.injectedLong;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_long() {
+        properties.put("test:long", "123");
+        LongContainer dummy = this.injector.getInstance(LongContainer.class);
+        assertThat(dummy.getInjectedLong(), is(123L));
+        properties.put("test:long", "-123");
+        dummy = this.injector.getInstance(LongContainer.class);
+        assertThat(dummy.getInjectedLong(), is(-123L));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_long() {
+        LongAllowNullContainer dummy = this.injector.getInstance(
+            LongAllowNullContainer.class);
+        assertThat(dummy.getInjectedLong(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_long() {
+        LongContainer dummy = this.injector.getInstance(LongContainer.class);
+        assertThat(dummy.getInjectedLong(), is(0L));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_long() {
+        // Test for case where no value is present in redis database.
+        LongDefaultValueContainer dummy = this.injector.getInstance(
+            LongDefaultValueContainer.class);
+        assertThat(dummy.getInjectedLong(), is(123L));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:long", "456");
+        dummy = this.injector.getInstance(LongDefaultValueContainer.class);
+        assertThat(dummy.getInjectedLong(), is(456L));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_long() {
+        properties.put("test:long", "invalid");
+        this.injector.getInstance(LongContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_long() {
+        properties.put("test:long", "-9223372036854775809");
+        this.injector.getInstance(LongContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_long() {
+        properties.put("test:long", "9223372036854775808");
+        this.injector.getInstance(LongContainer.class);
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/MapInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/MapInjectionTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
 import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import com.google.common.collect.Maps;
 import java.util.Properties;
 
 /**
@@ -230,5 +231,25 @@ public class MapInjectionTest extends AbstractModule {
         Set<Map<String, String>> actualMapSet = dummy.getInjectedMap();
         assertThat(actualMapSet.size(), is(1));
         assertThat(Iterables.getOnlyElement(actualMapSet), is(equalTo(expectedMap)));
+    }
+
+    public static class NullMapContainer {
+        
+        @Config(value = "test:map",allowNull = false)
+        private Map<String, String> injectedMap;
+        
+        public Map<String, String> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    @Test
+    public void test_that_null_is_not_injected_if_key_not_present() {
+        this.properties.clear();
+        NullMapContainer dummy = this.injector.getInstance(NullMapContainer.class);
+        Map<String, String> actualMapSet = dummy.getInjectedMap();
+        Map<String, String> expectedMap = Maps.newHashMap();
+        assertThat(actualMapSet.size(), is(0));
+        assertThat(actualMapSet, is(equalTo(expectedMap)));
     }
 }

--- a/src/test/java/com/github/strawberry/guice/config/MapInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/MapInjectionTest.java
@@ -1,0 +1,234 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class MapInjectionTest extends AbstractModule {
+    
+    private Injector injector;
+    Properties properties = new Properties();
+    
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+        properties.clear();
+    }
+
+    @After
+    public void teardown() {
+    }
+    
+    
+    
+    public static class MapContainer {
+
+        @Config(value = "test:map", allowNull = false)
+        private Map<String, String> injectedMap;
+
+        public Map<String, String> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    public static class MapAllowNullContainer {
+
+        @Config("test:map")
+        private Map<String, String> injectedMap;
+
+        public Map<String, String> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    public static class MapDefaultValueContainer {
+        
+        @Config("test:map")
+        private Map<String, String> injectedMap = ImmutableMap.of(
+            "def_key_01", "def_value_01",
+            "def_key_02", "def_value_02",
+            "def_key_03", "def_value_03"
+        );
+        
+        public Map<String, String> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    @Test
+    public void test_that_map_is_injected_into_map() {
+        Map<String, String> expectedMap = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        this.properties.put("test:map", expectedMap);
+        MapContainer dummy = this.injector.getInstance(MapContainer.class);
+        assertThat(dummy.getInjectedMap(), is(equalTo(expectedMap)));
+    }
+    
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_map() {
+        MapAllowNullContainer dummy = this.injector.getInstance(
+            MapAllowNullContainer.class);
+        assertThat(dummy.getInjectedMap(), is(nullValue()));
+    }
+    
+    @Test
+    public void test_that_missing_value_is_injected_as_empty_map_into_map() {
+        MapContainer dummy = this.injector.getInstance(MapContainer.class);
+        assertThat(dummy.getInjectedMap(), is(equalTo(Collections.EMPTY_MAP)));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_map() {
+        // Test for case where no value is present in redis database.
+        MapDefaultValueContainer dummy = this.injector.getInstance(
+            MapDefaultValueContainer.class);
+        Map<String, String> defaultMap = ImmutableMap.of(
+            "def_key_01", "def_value_01",
+            "def_key_02", "def_value_02",
+            "def_key_03", "def_value_03"
+        );
+        assertThat(dummy.getInjectedMap(), is(equalTo(defaultMap)));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        Map<String, String> expectedMap = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        this.properties.put("test:map", expectedMap);
+        dummy = this.injector.getInstance(MapDefaultValueContainer.class);
+        assertThat(dummy.getInjectedMap(), is(equalTo(expectedMap)));
+    }
+    
+    
+    
+    public static class MapInMapContainer {
+
+        @Config("test:map")
+        private Map<String, Map<String, String>> injectedMap;
+
+        public Map<String, Map<String, String>> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    @Test
+    public void test_that_map_is_injected_into_map_of_map() {
+        Map<String, String> expectedMap = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        this.properties.put("test:map", expectedMap);
+        MapInMapContainer dummy = this.injector.getInstance(MapInMapContainer.class);
+        Map<String, Map<String, String>> actualMapMap = dummy.getInjectedMap();
+        assertThat(actualMapMap.size(), is(1));
+        assertThat(actualMapMap.get("test:map"), is(equalTo(expectedMap)));
+    }
+    
+    
+    
+    public static class MapInListContainer {
+
+        @Config("test:map")
+        private List<Map<String, String>> injectedMap;
+
+        public List<Map<String, String>> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    @Test
+    public void test_that_map_is_injected_into_list_of_map() {
+        Map<String, String> expectedMap = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        this.properties.put("test:map", expectedMap);
+        MapInListContainer dummy = this.injector.getInstance(MapInListContainer.class);
+        List<Map<String, String>> actualMapList = dummy.getInjectedMap();
+        assertThat(actualMapList.size(), is(1));
+        assertThat(actualMapList.get(0), is(equalTo(expectedMap)));
+    }
+    
+    
+    
+    public static class MapInSetContainer {
+        
+        @Config("test:map")
+        private Set<Map<String, String>> injectedMap;
+        
+        public Set<Map<String, String>> getInjectedMap() {
+            return this.injectedMap;
+        }
+    }
+    
+    @Test
+    public void test_that_map_is_injected_into_set_of_map() {
+        Map<String, String> expectedMap = ImmutableMap.of(
+            "key_01", "value_01",
+            "key_02", "value_02",
+            "key_03", "value_03"
+        );
+        this.properties.put("test:map", expectedMap);
+        MapInSetContainer dummy = this.injector.getInstance(MapInSetContainer.class);
+        Set<Map<String, String>> actualMapSet = dummy.getInjectedMap();
+        assertThat(actualMapSet.size(), is(1));
+        assertThat(Iterables.getOnlyElement(actualMapSet), is(equalTo(expectedMap)));
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/ShortInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/ShortInjectionTest.java
@@ -1,0 +1,236 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class ShortInjectionTest extends AbstractModule {
+
+    private Injector injector;
+
+    Properties properties = new Properties();
+
+    @Override
+    protected void configure() {
+        install(new ConfigModule(this.properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class PrimitiveShortContainer {
+
+        @Config(value = "test:short", allowNull = false)
+        private short injectedShort;
+
+        public short getInjectedShort() {
+            return this.injectedShort;
+        }
+    }
+
+    public static class PrimitiveShortAllowNullContainer {
+
+        @Config(value = "test:short", forceUpdate = true)
+        private short injectedShort;
+
+        public short getInjectedShort() {
+            return this.injectedShort;
+        }
+    }
+    
+    public static class PrimitiveShortDefaultValueContainer {
+
+        @Config("test:short")
+        private short injectedShort = 123;
+
+        public short getInjectedShort() {
+            return this.injectedShort;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_primitive_short() {
+        properties.put("test:short", "123");
+        PrimitiveShortContainer dummy = this.injector.getInstance(PrimitiveShortContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)123));
+        properties.put("test:short", "-123");
+        dummy = this.injector.getInstance(PrimitiveShortContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)-123));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_missing_value_causes_exception_when_setting_primitive_short_to_null() {
+        this.injector.getInstance(PrimitiveShortAllowNullContainer.class);
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_primitive_short() {
+        PrimitiveShortContainer dummy = this.injector.getInstance(
+            PrimitiveShortContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_primitive_short() {
+        // Test for case where no value is present in redis database.
+        PrimitiveShortDefaultValueContainer dummy = this.injector.getInstance(
+            PrimitiveShortDefaultValueContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)123));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:short", "456");
+        dummy = this.injector.getInstance(PrimitiveShortDefaultValueContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)456));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_primitive_short() {
+        properties.put("test:short", "invalid");
+        this.injector.getInstance(PrimitiveShortContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_primitive_short() {
+        properties.put("test:short", "-32,769");
+        this.injector.getInstance(PrimitiveShortContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_primitive_short() {
+        properties.put("test:short", "32,768");
+        this.injector.getInstance(PrimitiveShortContainer.class);
+    }
+
+
+
+    public static class ShortContainer {
+
+        @Config(value = "test:short", allowNull = false)
+        private Short injectedShort;
+
+        public Short getInjectedShort() {
+            return this.injectedShort;
+        }
+    }
+
+    public static class ShortAllowNullContainer {
+
+        @Config("test:short")
+        private Short injectedShort;
+
+        public Short getInjectedShort() {
+            return this.injectedShort;
+        }
+    }
+    
+    public static class ShortDefaultValueContainer {
+
+        @Config("test:short")
+        private Short injectedShort = 123;
+
+        public Short getInjectedShort() {
+            return this.injectedShort;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_converted_into_short() {
+        properties.put("test:short", "123");
+        ShortContainer dummy = this.injector.getInstance(ShortContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)123));
+        properties.put("test:short", "-123");
+        dummy = this.injector.getInstance(ShortContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)-123));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_short() {
+        ShortAllowNullContainer dummy = this.injector.getInstance(
+            ShortAllowNullContainer.class);
+        assertThat(dummy.getInjectedShort(), is(nullValue()));
+    }
+
+    @Test
+    public void test_that_missing_value_is_injected_as_zero_into_short() {
+        ShortContainer dummy = this.injector.getInstance(ShortContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)0));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_short() {
+        // Test for case where no value is present in redis database.
+        ShortDefaultValueContainer dummy = this.injector.getInstance(
+            ShortDefaultValueContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)123));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        properties.put("test:short", "456");
+        dummy = this.injector.getInstance(ShortDefaultValueContainer.class);
+        assertThat(dummy.getInjectedShort(), is((short)456));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_invalid_string_throws_exception_when_converting_to_short() {
+        properties.put("test:short", "invalid");
+        this.injector.getInstance(ShortContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_small_value_throws_exception_when_converting_to_short() {
+        properties.put("test:short", "-32,769");
+        this.injector.getInstance(ShortContainer.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_that_too_large_value_throws_exception_when_converting_to_short() {
+        properties.put("test:short", "32,768");
+        this.injector.getInstance(ShortContainer.class);
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/config/StringInjectionTest.java
+++ b/src/test/java/com/github/strawberry/guice/config/StringInjectionTest.java
@@ -1,0 +1,199 @@
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.strawberry.guice.config;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import static com.github.strawberry.util.JedisUtil.destroyOnShutdown;
+import java.util.Properties;
+
+/**
+ *
+ * @author Wiehann Matthysen
+ */
+public class StringInjectionTest extends AbstractModule {
+
+    private Injector injector;
+    Properties properties = new Properties();
+    @Override
+    protected void configure() {
+        install(new ConfigModule(properties));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+
+
+    public static class StringContainer {
+
+        @Config(value = "test:string", allowNull = false)
+        private String injectedString;
+
+        public String getInjectedString() {
+            return this.injectedString;
+        }
+    }
+    
+    public static class StringAllowNullContainer {
+
+        @Config("test:string")
+        private String injectedString;
+
+        public String getInjectedString() {
+            return this.injectedString;
+        }
+    }
+    
+    public static class StringDefaultValueContainer {
+
+        @Config("test:string")
+        private String injectedString = "default_value";
+
+        public String getInjectedString() {
+            return this.injectedString;
+        }
+    }
+    
+    @Test
+    public void test_that_string_is_injected_into_string() {
+        String expectedString = "test_value";
+        properties.put("test:string", expectedString);
+        StringContainer dummy = this.injector.getInstance(StringContainer.class);
+        assertThat(dummy.getInjectedString(), is(equalTo(expectedString)));
+    }
+    
+    @Test
+    public void test_that_missing_value_is_injected_as_null_into_string() {
+        StringAllowNullContainer dummy = this.injector.getInstance(
+            StringAllowNullContainer.class);
+        assertThat(dummy.getInjectedString(), is(nullValue()));
+    }
+    
+    @Test
+    public void test_that_missing_value_is_injected_as_blank_into_string() {
+        StringContainer dummy = this.injector.getInstance(StringContainer.class);
+        assertThat(dummy.getInjectedString(), is(equalTo("")));
+    }
+    
+    @Test
+    public void test_that_missing_value_causes_default_value_to_be_set_for_string() {
+        // Test for case where no value is present in redis database.
+        StringDefaultValueContainer dummy = this.injector.getInstance(
+            StringDefaultValueContainer.class);
+        assertThat(dummy.getInjectedString(), is(equalTo("default_value")));
+        
+        // Test for case where value is present in redis database.
+        // Default value should be overwritten.
+        String expectedString = "test_value";
+        properties.put("test:string", expectedString);
+        dummy = this.injector.getInstance(StringDefaultValueContainer.class);
+        assertThat(dummy.getInjectedString(), is(equalTo(expectedString)));
+    }
+    
+    
+    
+    public static class StringInMapContainer {
+
+        @Config("test:string")
+        private Map<String, String> injectedString;
+
+        public Map<String, String> getInjectedString() {
+            return this.injectedString;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_map() {
+        String expectedString = "test_value";
+        properties.put("test:string", expectedString);
+        StringInMapContainer dummy = this.injector.getInstance(StringInMapContainer.class);
+        Map<String, String> actualStringMap = dummy.getInjectedString();
+        assertThat(actualStringMap.size(), is(1));
+        assertThat(actualStringMap.get("test:string"), is(equalTo(expectedString)));
+    }
+    
+    
+    
+    public static class StringInListContainer {
+
+        @Config("test:string")
+        private List<String> injectedString;
+
+        public List<String> getInjectedString() {
+            return this.injectedString;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_list() {
+        String expectedString = "test_value";
+        properties.put("test:string", expectedString);
+        StringInListContainer dummy = this.injector.getInstance(StringInListContainer.class);
+        List<String> actualStringList = dummy.getInjectedString();
+        assertThat(actualStringList.size(), is(1));
+        assertThat(actualStringList.get(0), is(equalTo(expectedString)));
+    }
+    
+    
+    
+    public static class StringInSetContainer {
+
+        @Config("test:string")
+        private Set<String> injectedString;
+
+        public Set<String> getInjectedString() {
+            return this.injectedString;
+        }
+    }
+
+    @Test
+    public void test_that_string_is_injected_into_set() {
+        String expectedString = "test_value";
+        properties.put("test:string", expectedString);
+        StringInSetContainer dummy = this.injector.getInstance(StringInSetContainer.class);
+        Set<String> actualStringSet = dummy.getInjectedString();
+        assertThat(actualStringSet.size(), is(1));
+        assertThat(Iterables.getOnlyElement(actualStringSet), is(equalTo(expectedString)));
+    }
+}

--- a/src/test/java/com/github/strawberry/guice/json/JsonTest.java
+++ b/src/test/java/com/github/strawberry/guice/json/JsonTest.java
@@ -1,6 +1,19 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * Strawberry Library
+ * Copyright (C) 2011 - 2012
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 package com.github.strawberry.guice.json;
 

--- a/src/test/java/com/github/strawberry/guice/json/JsonTest.java
+++ b/src/test/java/com/github/strawberry/guice/json/JsonTest.java
@@ -1,0 +1,70 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.strawberry.guice.json;
+
+import com.github.strawberry.guice.Config;
+import com.github.strawberry.guice.ConfigModule;
+import com.github.strawberry.util.Json;
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ *
+ * @author nicok
+ */
+public class JsonTest extends AbstractModule {;
+
+    private Injector injector;
+    
+    @Override
+    protected void configure() {
+        String json = "{\"mynumber\":1,\"mystring\":\"My String\",\"mylist\":[1,2,3]}";
+        Map m = Json.parse(json);
+        install(new ConfigModule(m));
+    }
+
+    @Before
+    public void setup() {
+        this.injector = Guice.createInjector(this);
+    }
+
+    @After
+    public void teardown() {
+    }
+
+     public static class Container {
+
+        @Config(value = "mynumber", allowNull = false)
+        Integer mynumber;
+
+        @Config(value = "mystring", allowNull = false)
+        String mystring;
+
+        @Config(value = "mylist", allowNull = false)
+        List<Integer> mylist;
+
+    }
+ 
+    @Test
+    public void testJson() {
+        Container c = injector.getInstance(Container.class);
+
+        assertThat(c.mystring, is("My String"));
+        assertThat(c.mynumber, is(1));
+        List<Integer> expectedList = Lists.newArrayList(1,2,3);
+        assertThat(c.mylist, is(equalTo(expectedList)));
+
+    }
+}


### PR DESCRIPTION
Expanded strawberry Guice loaders to be able to accept an arbitrary Map of objects, which can then in turn be loaded from JSON, for example.

Check out the single test in json package as an example, and also the new tests in config package for examples of the basics.

Basic flow is JSON -> Map<String,Object> -> Guiced
